### PR TITLE
Add format and style check pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install formatters
-        run: pip install clang-format==19.1.7 autopep8==2.3.2
+        run: pip install clang-format==22.1.5 autopep8==2.3.2
       - name: Check formatting
         run: python3 dev/check_format.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,19 @@ jobs:
     uses: ./.github/workflows/build.yml
     secrets: inherit
 
+  # runs unconditionally: it is cheap and also covers files outside the code filter (e.g. docs)
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install formatters
+        run: pip install clang-format==19.1.7 autopep8==2.3.2
+      - name: Check formatting
+        run: python3 dev/check_format.py
+
   ci:
     if: always()
-    needs: [changes, build]
+    needs: [changes, build, format]
     runs-on: ubuntu-latest
     steps:
       - run: exit 1

--- a/build_system/utils.py
+++ b/build_system/utils.py
@@ -50,12 +50,12 @@ def extract_zip(zip_path, extract_to):
 def compress_zip(source_path, zip_path):
     """Compress a folder or file into a zip archive."""
     print(f"Compressing {source_path} to {zip_path} ...")
-    
+
     # Ensure the destination directory exists
     parent = os.path.dirname(zip_path)
     if parent:
         os.makedirs(parent, exist_ok=True)
-    
+
     with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zip_ref:
         if os.path.isfile(source_path):
             # Single file

--- a/dev/check_format.py
+++ b/dev/check_format.py
@@ -1,0 +1,110 @@
+"""Check or fix source formatting for the whole repository.
+
+Runs the same formatters CI uses, over all git-tracked files (thirdparty excluded):
+
+* c++/objc/slang: clang-format (major version pinned below, using .clang-format)
+* python: autopep8 (configured in pyproject.toml)
+* markdown: markdownlint via npx (configured in .markdownlint.json)
+
+Usage:
+    python3 dev/check_format.py          # report violations, exit 1 if any
+    python3 dev/check_format.py --fix    # rewrite files in place
+"""
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+
+# majors verified to produce identical results on this codebase
+CLANG_FORMAT_SUPPORTED_MAJORS = range(18, 23)
+CLANG_FORMAT_PIP_SPEC = "clang-format==19.1.7"
+MARKDOWNLINT_NPX_SPEC = "markdownlint-cli@0.45.0"
+
+# keep command lines short enough for Windows
+CHUNK_SIZE = 50
+
+
+def git_files(*patterns):
+    output = subprocess.check_output(
+        ["git", "ls-files", "--", *patterns], text=True)
+    return [f for f in output.splitlines() if not f.startswith("thirdparty/")]
+
+
+def run_chunked(base_cmd, files):
+    """Run base_cmd over files in chunks. Returns True if all runs succeed."""
+    ok = True
+    for i in range(0, len(files), CHUNK_SIZE):
+        result = subprocess.run(base_cmd + files[i:i + CHUNK_SIZE])
+        ok = ok and result.returncode == 0
+    return ok
+
+
+def check_clang_format(fix):
+    files = git_files("*.cpp", "*.h", "*.mm", "*.m", "*.slang", "*.slangh")
+
+    if not shutil.which("clang-format"):
+        print(f"ERROR: clang-format not found. Install with: pip install {CLANG_FORMAT_PIP_SPEC}")
+        return False
+
+    version_output = subprocess.check_output(["clang-format", "--version"], text=True)
+    match = re.search(r"version (\d+)", version_output)
+    if not match or int(match.group(1)) not in CLANG_FORMAT_SUPPORTED_MAJORS:
+        print(f"ERROR: clang-format major version must be in "
+              f"[{CLANG_FORMAT_SUPPORTED_MAJORS.start}, {CLANG_FORMAT_SUPPORTED_MAJORS.stop - 1}], "
+              f"got: {version_output.strip()}")
+        print(f"Install with: pip install {CLANG_FORMAT_PIP_SPEC}")
+        return False
+
+    mode = ["-i"] if fix else ["--dry-run", "--Werror"]
+    return run_chunked(["clang-format"] + mode, files)
+
+
+def check_autopep8(fix):
+    files = git_files("*.py")
+
+    if not shutil.which("autopep8"):
+        print("ERROR: autopep8 not found. Install with: pip install autopep8")
+        return False
+
+    mode = ["--in-place"] if fix else ["--diff", "--exit-code"]
+    return run_chunked(["autopep8"] + mode, files)
+
+
+def check_markdownlint(fix):
+    files = git_files("*.md")
+
+    npx = shutil.which("npx")
+    if not npx:
+        print("ERROR: npx not found. Install Node.js to run markdownlint.")
+        return False
+
+    mode = ["--fix"] if fix else []
+    return run_chunked([npx, "--yes", MARKDOWNLINT_NPX_SPEC] + mode, files)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fix", action="store_true",
+                        help="rewrite files in place instead of just checking")
+    args = parser.parse_args()
+
+    results = {
+        "clang-format": check_clang_format(args.fix),
+        "autopep8": check_autopep8(args.fix),
+        "markdownlint": check_markdownlint(args.fix),
+    }
+
+    failed = [name for name, ok in results.items() if not ok]
+    if failed:
+        print(f"\nFormat check FAILED: {', '.join(failed)}")
+        if not args.fix:
+            print("Run 'python3 dev/check_format.py --fix' to fix automatically.")
+        sys.exit(1)
+
+    print("\nFormat check passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/check_format.py
+++ b/dev/check_format.py
@@ -19,7 +19,7 @@ import sys
 
 # majors verified to produce identical results on this codebase
 CLANG_FORMAT_SUPPORTED_MAJORS = range(18, 23)
-CLANG_FORMAT_PIP_SPEC = "clang-format==19.1.7"
+CLANG_FORMAT_PIP_SPEC = "clang-format==22.1.5"
 MARKDOWNLINT_NPX_SPEC = "markdownlint-cli@0.45.0"
 
 # keep command lines short enough for Windows

--- a/dev/functional_test.py
+++ b/dev/functional_test.py
@@ -48,9 +48,9 @@ def build_and_run(framework, pipeline, scene, other_args, headless=False, env=No
     if skip_build:
         run_cmd.append("--skip_build")
     run_cmd += ["--run",
-               "--test_case", "screenshot",
-               "--clear_screenshots", "true",
-               "--pipeline", pipeline] + other_args
+                "--test_case", "screenshot",
+                "--clear_screenshots", "true",
+                "--pipeline", pipeline] + other_args
 
     if headless:
         run_cmd += ["--headless", "true"]
@@ -144,8 +144,8 @@ def main():
 
     if not args.skip_run:
         build_and_run(args.framework, args.pipeline,
-                args.scene, unknown_args, headless=args.headless, env=env,
-                skip_build=args.skip_build)
+                      args.scene, unknown_args, headless=args.headless, env=env,
+                      skip_build=args.skip_build)
     else:
         print("Skipping app run, using existing screenshot.")
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -5,7 +5,23 @@
 * A CI pipeline is setup in github [actions](https://github.com/tqjxlm/Sparkle/actions) at .github/workflows/ci.yml
 * Pushing tags will generate releases on github. The release process is defined in .github/workflows/release.yml.
 * All PRs are required to pass CI before merging.
-* For now, there are a building test and a very basic functional test. Unit test, performance test and style check are coming soon.
+* For now, there are a format check, a building test and a very basic functional test. Unit test and performance test are coming soon.
+
+## Format Check
+
+* Format check is run on every push and PR, regardless of which files changed.
+* It verifies that all tracked source files (thirdparty excluded) match the output of the project formatters:
+  * c++/objc/slang: clang-format with [.clang-format](../.clang-format)
+  * python: autopep8, configured in [pyproject.toml](../pyproject.toml)
+  * markdown: markdownlint with [.markdownlint.json](../.markdownlint.json)
+* Run it locally before pushing:
+
+```bash
+python3 dev/check_format.py          # check only
+python3 dev/check_format.py --fix    # rewrite files in place
+```
+
+* Requirements: `pip install clang-format==19.1.7 autopep8` and Node.js (markdownlint runs via npx). clang-format majors 18-22 all produce identical results on this codebase; CI pins 19.1.7.
 
 ## Build Test
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -21,7 +21,7 @@ python3 dev/check_format.py          # check only
 python3 dev/check_format.py --fix    # rewrite files in place
 ```
 
-* Requirements: `pip install clang-format==19.1.7 autopep8` and Node.js (markdownlint runs via npx). clang-format majors 18-22 all produce identical results on this codebase; CI pins 19.1.7.
+* Requirements: `pip install clang-format==22.1.5 autopep8` and Node.js (markdownlint runs via npx). clang-format majors 18-22 all produce identical results on this codebase; CI pins 22.1.5.
 
 ## Build Test
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,8 +25,11 @@ Always use formatters in the environment or IDE to format code and documents aft
 
 * c++/objc/slang: `.clang-format` (clang-format)
 * markdown: `.markdownlint.json` (markdownlint)
-* python: PEP8 (autopep8)
+* python: PEP8 (autopep8, configured in `pyproject.toml`)
 * All code must pass clang-tidy with the project's [.clang-tidy](../.clang-tidy) configuration. All warnings are treated as errors (`WarningsAsErrors: "*"`).
+
+CI enforces formatting on every push and PR. Check or fix everything locally with
+`python3 dev/check_format.py [--fix]`. See [CI.md](CI.md) for details.
 
 ### Naming Conventions
 

--- a/docs/Nrd.md
+++ b/docs/Nrd.md
@@ -4,7 +4,7 @@ NVIDIA NRD (ReBLUR_DIFFUSE_SPECULAR) denoises the gpu path tracer: `--pipeline g
 
 ## Architecture
 
-```
+```text
 ray_trace.cs.slang        WritePrimaryHitGBuffer: noise-free primary-hit G-buffer
                           (radiance+hitT, normal+viewZ, albedo+objID, motion+isHit, specAlbedo+roughness)
         |

--- a/docs/RenderingValidation.md
+++ b/docs/RenderingValidation.md
@@ -26,6 +26,7 @@ Debugging a visual artifact is a two-gate, evidence-driven loop — **never "gue
 2. **Gate 2 — Agree the gate, then hold the fix to it. The gate is the agreed VISUALIZATION, not a number.** The gate is the Gate-1 overlay/diff/highlight the user confirmed shows the defect: the fix succeeds only when the **highlighted defect pixels are eliminated in that same image, regenerated after the fix.** Decide this *before* implementing. **Quantitative metrics are NOT the gate for rendering artifacts — they routinely give false confidence:** a metric can report a large "% improvement" while the agreed image still plainly shows the artifact. A number may *support* a semantic verdict, never replace or override it — when the number and the agreed image disagree, the image wins. **If asked for a purely quantitative criterion, push back**: it conflicts with semantic-first (checklist #4/#6, AGENTS.md) — gate on the agreed visualization instead.
 
 If you do compute a *supporting* number, design it to match the artifact's nature (from Gate 1) — but treat it as support only:
+
 * If the artifact is **per-frame / stochastic** (e.g. noise the filter spreads), measure per-frame; a naive M-average **cancels** it (and can read ~0 on a plainly-visible artifact).
 * If it is **localized**, restrict to a band derived from the **geometry G-buffer** (depth/normal discontinuity), *not* luma edges (luma "edges" leak surface texture and flood the mask).
 * Always compare against an **independent ground truth**.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,7 +2,7 @@
 
 ## CI/CD
 
-* [ ] format and style check pipeline
+* [x] format and style check pipeline
 * [ ] unit test pipeline
 * [ ] functional test pipeline
 * [ ] performance test pipeline

--- a/frameworks/include/glfw/GLFWNativeView.h
+++ b/frameworks/include/glfw/GLFWNativeView.h
@@ -18,6 +18,7 @@ public:
     bool ShouldClose() override;
     void Tick() override;
     void SetTitle(const char *title) override;
+
     [[nodiscard]] bool IsHeadless() const override
     {
         return headless_;

--- a/libraries/include/application/RenderFramework.h
+++ b/libraries/include/application/RenderFramework.h
@@ -21,11 +21,24 @@ struct ThreadTaskQueue;
 class ScreenshotRequest
 {
 public:
-    explicit ScreenshotRequest(std::string name) : name_(std::move(name)) {}
+    explicit ScreenshotRequest(std::string name) : name_(std::move(name))
+    {
+    }
 
-    [[nodiscard]] const std::string &GetName() const { return name_; }
-    [[nodiscard]] bool IsCompleted() const { return completed_.load(std::memory_order_acquire); }
-    void MarkCompleted() { completed_.store(true, std::memory_order_release); }
+    [[nodiscard]] const std::string &GetName() const
+    {
+        return name_;
+    }
+
+    [[nodiscard]] bool IsCompleted() const
+    {
+        return completed_.load(std::memory_order_acquire);
+    }
+
+    void MarkCompleted()
+    {
+        completed_.store(true, std::memory_order_release);
+    }
 
 private:
     std::string name_;

--- a/libraries/include/rhi/RHINrdBackend.h
+++ b/libraries/include/rhi/RHINrdBackend.h
@@ -45,9 +45,8 @@ public:
     // Allocate NRD's internal texture pool (each texture sized = render resolution / its downsample), the
     // samplers (nrd::Sampler values), and the per-dispatch constant buffer. Call once after AddPipeline().
     virtual void AllocateResources(uint32_t width, uint32_t height, const PoolTexture *permanent,
-                                   uint32_t permanent_count, const PoolTexture *transient,
-                                   uint32_t transient_count, const uint32_t *samplers, uint32_t sampler_count,
-                                   uint32_t constant_buffer_size) = 0;
+                                   uint32_t permanent_count, const PoolTexture *transient, uint32_t transient_count,
+                                   const uint32_t *samplers, uint32_t sampler_count, uint32_t constant_buffer_size) = 0;
 
     // One resource of one NRD dispatch, pre-resolved by the renderer from nrd::ResourceDesc: pool textures
     // live backend-side (referenced by index), user-facing IN_*/OUT_* textures come as engine images.

--- a/libraries/source/application/AppConfig.cpp
+++ b/libraries/source/application/AppConfig.cpp
@@ -7,8 +7,8 @@ namespace sparkle
 static ConfigValue<uint32_t> config_max_thread("thread", "maximum threads to use", "app", 64);
 // Empty (the default) => the built-in TestScene, which is also the scene the CI ground-truth images
 // are rendered from. A non-empty value is a model/scene file path (under resources/), not a scene name.
-static ConfigValue<std::string> config_scene("scene", "scene file path to render; empty = built-in TestScene",
-                                             "app", "");
+static ConfigValue<std::string> config_scene("scene", "scene file path to render; empty = built-in TestScene", "app",
+                                             "");
 static ConfigValue<bool> config_screen_log("screen_log", "show screen log", "app", true, true);
 static ConfigValue<bool> config_rebuild_cache("rebuild_cache", "rebuild all cache", "app", false);
 static ConfigValue<bool> config_default_skybox("default_sky", "use a default sky box", "app", false, true);
@@ -21,7 +21,9 @@ static ConfigValue<bool> config_headless("headless", "run without creating a win
 
 #if ENABLE_TEST_CASES
 static ConfigValue<std::string> config_test_case("test_case", "name of test case to run on scene load", "app", "");
-static ConfigValue<uint32_t> config_test_timeout("test_timeout", "max frames before a test case is considered timed out (0 = no limit)", "app", 0);
+static ConfigValue<uint32_t> config_test_timeout("test_timeout",
+                                                 "max frames before a test case is considered timed out (0 = no limit)",
+                                                 "app", 0);
 #endif
 
 void AppConfig::Init()

--- a/libraries/source/application/RenderFramework.cpp
+++ b/libraries/source/application/RenderFramework.cpp
@@ -133,8 +133,8 @@ void RenderFramework::RenderLoop()
 
             renderer_->Render();
 
-            ready_for_auto_screenshot_.store(
-                IsSceneFullyLoaded() && renderer_->IsReadyForAutoScreenshot(), std::memory_order_release);
+            ready_for_auto_screenshot_.store(IsSceneFullyLoaded() && renderer_->IsReadyForAutoScreenshot(),
+                                             std::memory_order_release);
 
             ProcessScreenshotRequest();
 

--- a/libraries/source/renderer/nrd/NrdConfig.cpp
+++ b/libraries/source/renderer/nrd/NrdConfig.cpp
@@ -8,8 +8,9 @@ static ConfigValue<bool> config_nrd("nrd", "enable NVIDIA NRD denoiser (gpu pipe
 static ConfigValue<bool> config_nrd_stabilization(
     "nrd_stabilization", "ReBLUR temporal stabilization pass (off saves one full-res pass; the resolve EMA remains)",
     "nrd", true, true);
-static ConfigValue<bool> config_nrd_radiance_fp16(
-    "nrd_radiance_fp16", "RGBA16F radiance G-buffers (half the bandwidth; init-time)", "nrd", true);
+static ConfigValue<bool> config_nrd_radiance_fp16("nrd_radiance_fp16",
+                                                  "RGBA16F radiance G-buffers (half the bandwidth; init-time)", "nrd",
+                                                  true);
 static ConfigValue<std::string> config_nrd_debug("nrd_debug", "NRD channel to visualize", "nrd",
                                                  Enum2Str<NrdDebugMode::None>(), true);
 

--- a/libraries/source/renderer/nrd/NrdDenoiser.cpp
+++ b/libraries/source/renderer/nrd/NrdDenoiser.cpp
@@ -120,8 +120,7 @@ public:
     };
 };
 
-NrdDenoiser::NrdDenoiser(RHIContext *ctx, RHIResourceRef<RHIImage> input)
-    : PipelinePass(ctx), input_(std::move(input))
+NrdDenoiser::NrdDenoiser(RHIContext *ctx, RHIResourceRef<RHIImage> input) : PipelinePass(ctx), input_(std::move(input))
 {
     SampleConfig();
     slot_ran_reblur_.resize(rhi_->GetMaxFramesInFlight(), 0);
@@ -220,8 +219,8 @@ void NrdDenoiser::AllocateGBuffer()
 
 void NrdDenoiser::BeginGBufferWrite()
 {
-    for (const auto &image : {g_radiance_, g_normal_depth_, g_albedo_obj_, g_motion_, g_radiance_specular_,
-                              g_spec_albedo_})
+    for (const auto &image :
+         {g_radiance_, g_normal_depth_, g_albedo_obj_, g_motion_, g_radiance_specular_, g_spec_albedo_})
     {
         ToLayout(image, RHIImageLayout::StorageWrite, RHIPipelineStage::Top, RHIPipelineStage::ComputeShader);
     }
@@ -272,8 +271,8 @@ void NrdDenoiser::EnsureEnabledResources()
         cooked.VersionBuild() != lib.versionBuild)
     {
         Log(Error, "NRD: cooked shaders are stale ({}.{}.{} vs NRD {}.{}.{}); rebuild to re-run the shader cook",
-            cooked.VersionMajor(), cooked.VersionMinor(), cooked.VersionBuild(), lib.versionMajor,
-            lib.versionMinor, lib.versionBuild);
+            cooked.VersionMajor(), cooked.VersionMinor(), cooked.VersionBuild(), lib.versionMajor, lib.versionMinor,
+            lib.versionBuild);
         enabled_resources_failed_ = true;
         return;
     }
@@ -450,8 +449,7 @@ void NrdDenoiser::Render()
     // The EMA must also die out with the ReBLUR contribution it smooths: its lag otherwise keeps the
     // display on an older, more-ReBLUR-flavored mix than handoff_weight says, and the final resolve
     // (beta pinned to 0) would release that lag as a visible pop right at the freeze.
-    const float stabilization_beta =
-        std::clamp(1.f - stabilization_rate, 0.f, 0.99f) * (1.f - handoff_weight);
+    const float stabilization_beta = std::clamp(1.f - stabilization_rate, 0.f, 0.99f) * (1.f - handoff_weight);
 
     // fully handed off to the accumulator: the ReBLUR result is weighted by zero, so skip its ~1.7 ms of
     // dispatches and run only the resolve (composite + stabilization). ReBLUR's history stays valid — the
@@ -544,15 +542,14 @@ void NrdDenoiser::RenderReblur(const Vector3UInt &dispatch, const Vector3UInt &g
 {
     const auto &attr = output_->GetAttributes();
 
-    for (const auto &image : {g_radiance_, g_radiance_specular_, g_normal_depth_, g_albedo_obj_, g_motion_,
-                              g_spec_albedo_})
+    for (const auto &image :
+         {g_radiance_, g_radiance_specular_, g_normal_depth_, g_albedo_obj_, g_motion_, g_spec_albedo_})
     {
         ToLayout(image, RHIImageLayout::Read, RHIPipelineStage::ComputeShader, RHIPipelineStage::ComputeShader);
     }
     for (const auto &image : {in_mv_, in_normal_roughness_, in_viewz_, in_diff_, in_spec_})
     {
-        ToLayout(image, RHIImageLayout::StorageWrite, RHIPipelineStage::ComputeShader,
-                 RHIPipelineStage::ComputeShader);
+        ToLayout(image, RHIImageLayout::StorageWrite, RHIPipelineStage::ComputeShader, RHIPipelineStage::ComputeShader);
     }
 
     NrdPackShader::UniformBufferData pack_ubo{
@@ -576,8 +573,7 @@ void NrdDenoiser::RenderReblur(const Vector3UInt &dispatch, const Vector3UInt &g
     }
     for (const auto &image : {out_diff_, out_spec_})
     {
-        ToLayout(image, RHIImageLayout::StorageWrite, RHIPipelineStage::ComputeShader,
-                 RHIPipelineStage::ComputeShader);
+        ToLayout(image, RHIImageLayout::StorageWrite, RHIPipelineStage::ComputeShader, RHIPipelineStage::ComputeShader);
     }
 
     // NRD assumes D3D clip conventions (+Y up); undo the engine's Vulkan-style Y flip (proj(1,1) < 0)
@@ -700,8 +696,8 @@ void NrdDenoiser::RenderReblur(const Vector3UInt &dispatch, const Vector3UInt &g
                     out.user_image = validation_.get();
                     break;
                 default:
-                    ASSERT_F(false, "NRD: unhandled resource type {} in dispatch '{}'",
-                             static_cast<uint32_t>(res.type), src.name ? src.name : "?");
+                    ASSERT_F(false, "NRD: unhandled resource type {} in dispatch '{}'", static_cast<uint32_t>(res.type),
+                             src.name ? src.name : "?");
                 }
                 break;
             }

--- a/libraries/source/renderer/renderer/CPURenderer.cpp
+++ b/libraries/source/renderer/renderer/CPURenderer.cpp
@@ -391,8 +391,7 @@ void CPURenderer::BasePass(const SceneRenderProxy &scene, const RenderConfig &co
             {
                 // Per-pixel seed: each pixel gets an independent, deterministic
                 // random sequence regardless of which thread processes this row.
-                sampler::ReseedCurrentThread(j * image_size_.x() + i +
-                                             frame_seed * image_size_.x() * image_size_.y());
+                sampler::ReseedCurrentThread(j * image_size_.x() + i + frame_seed * image_size_.x() * image_size_.y());
                 RenderPixel(i, j, pixel_width, pixel_height, scene, config, debug_point);
             }
         });

--- a/libraries/source/renderer/renderer/DeferredRenderer.cpp
+++ b/libraries/source/renderer/renderer/DeferredRenderer.cpp
@@ -197,8 +197,9 @@ void DeferredRenderer::Render()
             final_after_stage = RHIPipelineStage::Transfer;
         }
 
-        screen_color_->Transition(
-            {.target_layout = RHIImageLayout::Read, .after_stage = final_after_stage, .before_stage = RHIPipelineStage::PixelShader});
+        screen_color_->Transition({.target_layout = RHIImageLayout::Read,
+                                   .after_stage = final_after_stage,
+                                   .before_stage = RHIPipelineStage::PixelShader});
     }
 
     // screen pass: copy screen_color to final buffer

--- a/libraries/source/renderer/renderer/ForwardRenderer.cpp
+++ b/libraries/source/renderer/renderer/ForwardRenderer.cpp
@@ -207,8 +207,9 @@ void ForwardRenderer::Render()
             final_after_stage = RHIPipelineStage::Transfer;
         }
 
-        screen_color_->Transition(
-            {.target_layout = RHIImageLayout::Read, .after_stage = final_after_stage, .before_stage = RHIPipelineStage::PixelShader});
+        screen_color_->Transition({.target_layout = RHIImageLayout::Read,
+                                   .after_stage = final_after_stage,
+                                   .before_stage = RHIPipelineStage::PixelShader});
     }
 
     // screen pass: copy screen_color to final buffer

--- a/libraries/source/renderer/renderer/GPURenderer.cpp
+++ b/libraries/source/renderer/renderer/GPURenderer.cpp
@@ -159,8 +159,7 @@ void GPURenderer::Render()
             nrd_->RequestReset(); // freshly-allocated history is garbage; start clean
             // enabling after the render freeze: no pass would ever write the NRD output, so restart
             // accumulation (it re-converges through the handoff)
-            if (!camera->NeedClear() &&
-                camera->GetCumulatedSampleCount() >= render_config_.max_sample_per_pixel)
+            if (!camera->NeedClear() && camera->GetCumulatedSampleCount() >= render_config_.max_sample_per_pixel)
             {
                 camera->MarkPixelDirty();
             }
@@ -462,8 +461,7 @@ void GPURenderer::Update()
 
     spp_logger_.Tick();
 
-    Logger::LogToScreen("Accumulation",
-                        fmt::format("Accumulated samples: {}", camera->GetCumulatedSampleCount()));
+    Logger::LogToScreen("Accumulation", fmt::format("Accumulated samples: {}", camera->GetCumulatedSampleCount()));
 }
 
 void GPURenderer::MeasurePerformance()

--- a/libraries/source/rhi/RHI.cpp
+++ b/libraries/source/rhi/RHI.cpp
@@ -1,9 +1,9 @@
 #include "rhi/RHI.h"
 
+#include "application/NativeView.h"
 #include "core/Exception.h"
 #include "core/Profiler.h"
 #include "io/Image.h"
-#include "application/NativeView.h"
 
 #if FRAMEWORK_APPLE
 #include "rhi/MetalRHI.h"

--- a/libraries/source/rhi/metal/MetalNrdBackend.mm
+++ b/libraries/source/rhi/metal/MetalNrdBackend.mm
@@ -85,10 +85,9 @@ MetalNrdBackend::MetalNrdBackend(id<MTLDevice> device) : device_(device)
 bool MetalNrdBackend::AddPipeline(const CookedPipeline &pipeline)
 {
     NSError *error = nil;
-    id<MTLLibrary> library =
-        [device_ newLibraryWithSource:[NSString stringWithUTF8String:pipeline.msl_source.c_str()]
-                              options:compile_options_
-                                error:&error];
+    id<MTLLibrary> library = [device_ newLibraryWithSource:[NSString stringWithUTF8String:pipeline.msl_source.c_str()]
+                                                   options:compile_options_
+                                                     error:&error];
     if (!library)
     {
         Log(Error, "MetalNrdBackend: MSL compile failed: {}",
@@ -96,7 +95,8 @@ bool MetalNrdBackend::AddPipeline(const CookedPipeline &pipeline)
         return false;
     }
 
-    id<MTLFunction> function = [library newFunctionWithName:[NSString stringWithUTF8String:pipeline.entry_point.c_str()]];
+    id<MTLFunction> function =
+        [library newFunctionWithName:[NSString stringWithUTF8String:pipeline.entry_point.c_str()]];
     if (!function)
     {
         Log(Error, "MetalNrdBackend: entry '{}' not found", pipeline.entry_point);

--- a/libraries/source/rhi/vulkan/VulkanContext.cpp
+++ b/libraries/source/rhi/vulkan/VulkanContext.cpp
@@ -949,10 +949,9 @@ void VulkanContext::GetRequiredInstanceExtensions()
         std::vector<VkExtensionProperties> exts(ext_count);
         vkEnumerateInstanceExtensionProperties(nullptr, &ext_count, exts.data());
 
-        bool layer_settings_available =
-            std::ranges::any_of(exts, [](const VkExtensionProperties &e) {
-                return std::string_view(e.extensionName) == VK_EXT_LAYER_SETTINGS_EXTENSION_NAME;
-            });
+        bool layer_settings_available = std::ranges::any_of(exts, [](const VkExtensionProperties &e) {
+            return std::string_view(e.extensionName) == VK_EXT_LAYER_SETTINGS_EXTENSION_NAME;
+        });
         if (layer_settings_available)
         {
             instance_extensions_.push_back(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);

--- a/libraries/source/rhi/vulkan/VulkanRHI.cpp
+++ b/libraries/source/rhi/vulkan/VulkanRHI.cpp
@@ -239,8 +239,8 @@ void VulkanRHI::CreateBackBufferRenderTarget()
     else
     {
         context->RecreateSwapChain();
-        back_buffer_rt_ =
-            CreateBackBufferRenderTarget({}, CreateBackBufferDepth(context->GetSwapChain()->GetExtent()), "BackBufferRT");
+        back_buffer_rt_ = CreateBackBufferRenderTarget({}, CreateBackBufferDepth(context->GetSwapChain()->GetExtent()),
+                                                       "BackBufferRT");
     }
 
     back_buffer_dirty_ = true;

--- a/libraries/source/scene/component/RenderableComponent.cpp
+++ b/libraries/source/scene/component/RenderableComponent.cpp
@@ -5,7 +5,6 @@
 #include "renderer/proxy/SceneRenderProxy.h"
 #include "scene/Scene.h"
 
-
 namespace sparkle
 {
 RenderableComponent::RenderableComponent()

--- a/libraries/source/scene/component/light/DirectionalLight.cpp
+++ b/libraries/source/scene/component/light/DirectionalLight.cpp
@@ -6,7 +6,6 @@
 #include "renderer/proxy/SceneRenderProxy.h"
 #include "scene/Scene.h"
 
-
 namespace sparkle
 {
 DirectionalLight::DirectionalLight() = default;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.autopep8]
+max_line_length = 120

--- a/resources/setup.py
+++ b/resources/setup.py
@@ -4,6 +4,7 @@ from build_system.utils import download_file, extract_zip
 SCRIPT = os.path.abspath(__file__)
 SCRIPTPATH = os.path.dirname(SCRIPT)
 
+
 def setup_resources():
     packed_dir = os.path.join(SCRIPTPATH, "packed")
     zip_path = os.path.join(SCRIPTPATH, "resources.zip")

--- a/shaders/include/ray_trace.h.slang
+++ b/shaders/include/ray_trace.h.slang
@@ -4,8 +4,8 @@
 #include "debug.h.slang"
 #include "random.h.slang"
 #include "sampler.h.slang"
-#include "tangent_space.h.slang"
 #include "standard.h.slang"
+#include "tangent_space.h.slang"
 
 struct Ray
 {
@@ -44,7 +44,7 @@ SampleResult BxdfSpecular(float3 local_w_o, MaterialParameters mat_param)
     SampleResult result;
     result.is_valid = false;
     result.pdf = 0.0f;
-    
+
     float3 local_w_m = SampleMicroFacetNormal(local_w_o, mat_param.roughness);
     float3 local_w_i = reflect(-local_w_o, local_w_m);
 
@@ -103,8 +103,8 @@ SampleResult BxdfLambertian(float3 local_w_o, MaterialParameters mat_param)
     return result;
 }
 
-float3 BxdfMetal(float3 w_o, out float3 w_i, out float out_pdf, out bool is_specular_lobe,
-                 MaterialParameters mat_param, Intersection intersection)
+float3 BxdfMetal(float3 w_o, out float3 w_i, out float out_pdf, out bool is_specular_lobe, MaterialParameters mat_param,
+                 Intersection intersection)
 {
     // enter tangent space
     float3 local_w_o = normalize(TransformBasisToLocal(w_o, intersection.normal, intersection.tangent.xyz));
@@ -149,7 +149,7 @@ float3 BxdfDieletric(float3 w_o, out float3 w_i, out float out_pdf, out bool is_
     {
         // Reflection
         local_w_i = Reflect(local_w_o);
-        out_pdf = fresnel;  // Probability of reflection
+        out_pdf = fresnel; // Probability of reflection
     }
     else
     {
@@ -157,7 +157,7 @@ float3 BxdfDieletric(float3 w_o, out float3 w_i, out float out_pdf, out bool is_
         bool is_entering = CosTheta(local_w_o) > 0;
         float eta_i_over_eta_t = is_entering ? eta_i_ / eta_t_ : eta_t_ / eta_i_;
         local_w_i = Refract(local_w_o, eta_i_over_eta_t);
-        out_pdf = 1.0f - fresnel;  // Probability of refraction
+        out_pdf = 1.0f - fresnel; // Probability of refraction
     }
 
     // back to world space

--- a/shaders/include/sampler.h.slang
+++ b/shaders/include/sampler.h.slang
@@ -110,7 +110,7 @@ float Pdf(float3 normal, float3 w_i)
 {
     return SaturateDot(normal, w_i) * InvPi;
 }
-}
+} // namespace CosineWeightedHemisphere
 
 float SmithGGX(float cos_o, float cos_i, float roughness)
 {

--- a/shaders/nrd/nrd_pack.cs.slang
+++ b/shaders/nrd/nrd_pack.cs.slang
@@ -34,8 +34,7 @@ float Luma(float3 c)
     return dot(c, float3(0.2126f, 0.7152f, 0.0722f));
 }
 
-[shader("compute")]
-[numthreads(16, 16, 1)] void shader_main(uint3 DTid : SV_DispatchThreadID) {
+[shader("compute")][numthreads(16, 16, 1)] void shader_main(uint3 DTid : SV_DispatchThreadID) {
     uint2 pixel = DTid.xy;
     if (pixel.x >= resolution.x || pixel.y >= resolution.y)
     {
@@ -109,8 +108,7 @@ float Luma(float3 c)
 
     float3 hit_dist_params = float3(hitDistA, hitDistB, hitDistC);
     float diff_norm_hd = saturate(radiance_hd.w / NrdHitDistanceNormalization(view_z, hit_dist_params, 1.f));
-    float spec_norm_hd =
-        saturate(spec_radiance_hd.w / NrdHitDistanceNormalization(view_z, hit_dist_params, roughness));
+    float spec_norm_hd = saturate(spec_radiance_hd.w / NrdHitDistanceNormalization(view_z, hit_dist_params, roughness));
 
     // raw hit distance 0 = that lobe was not sampled this frame (probabilistic primary-lobe selection).
     // NRD requires EXACTLY 0 there (HitDistanceReconstructionMode fills from neighbors); any positive

--- a/shaders/nrd/nrd_resolve.cs.slang
+++ b/shaders/nrd/nrd_resolve.cs.slang
@@ -12,8 +12,8 @@
     uint2 resolution;
     uint mode;
     float demodEps;
-    float viewZScale;   // debug display: view_z / viewZScale
-    float motionScale;  // debug display: uv motion * motionScale
+    float viewZScale;  // debug display: view_z / viewZScale
+    float motionScale; // debug display: uv motion * motionScale
     // Convergence handoff: ReBLUR's capped history has a permanent noise floor (it re-blends fresh 1-spp
     // noise every frame), so a static view would shimmer forever. Cross-fade to the progressive
     // accumulator as it converges; under motion the accumulator resets, so the weight is 0 there.
@@ -31,17 +31,16 @@
 [[vk::binding(5, 0)]] Texture2D<float4> inViewZ;
 [[vk::binding(6, 0)]] Texture2D<float4> inDiff;
 [[vk::binding(7, 0)]] Texture2D<float4> inSpec;
-[[vk::binding(8, 0)]] Texture2D<float4> gRadiance;   // raw per-frame radiance (sky fallback)
+[[vk::binding(8, 0)]] Texture2D<float4> gRadiance; // raw per-frame radiance (sky fallback)
 [[vk::binding(9, 0)]] Texture2D<float4> gAlbedoObj;
-[[vk::binding(10, 0)]] Texture2D<float4> gMotion;    // z: is-hit
+[[vk::binding(10, 0)]] Texture2D<float4> gMotion; // z: is-hit
 [[vk::binding(11, 0)]] Texture2D<float4> gSpecAlbedo;
 [[vk::binding(12, 0)]] RWTexture2D<float4> outputImage;
-[[vk::binding(14, 0)]] Texture2D<float4> validation; // NRD OUT_VALIDATION overlay (.w: transparency)
-[[vk::binding(15, 0)]] Texture2D<float4> sceneAccum;  // progressive accumulator (converged reference)
+[[vk::binding(14, 0)]] Texture2D<float4> validation;      // NRD OUT_VALIDATION overlay (.w: transparency)
+[[vk::binding(15, 0)]] Texture2D<float4> sceneAccum;      // progressive accumulator (converged reference)
 [[vk::binding(16, 0)]] RWTexture2D<float4> outputHistory; // previous stabilized output (read-modify-write)
 
-[shader("compute")]
-[numthreads(16, 16, 1)] void shader_main(uint3 DTid : SV_DispatchThreadID) {
+[shader("compute")][numthreads(16, 16, 1)] void shader_main(uint3 DTid : SV_DispatchThreadID) {
     uint2 pixel = DTid.xy;
     if (pixel.x >= resolution.x || pixel.y >= resolution.y)
     {

--- a/shaders/ray_trace/ray_trace.cs.slang
+++ b/shaders/ray_trace/ray_trace.cs.slang
@@ -46,10 +46,10 @@ struct Camera
 
 // Denoiser G-buffer outputs (written only when write_gbuffer != 0). The path tracer carries no denoiser
 // math here: it just emits generic primary-hit attributes + the current frame's raw radiance.
-[[vk::binding(7, 1)]] RWTexture2D<float4> gRadiance;    // rgb: this-frame mean radiance
-[[vk::binding(8, 1)]] RWTexture2D<float4> gNormalDepth; // xyz: world normal, w: view-space linear z
-[[vk::binding(9, 1)]] RWTexture2D<float4> gAlbedoObj;   // rgb: base color, w: object id
-[[vk::binding(10, 1)]] RWTexture2D<float4> gMotion;     // xy: screen motion vector, z: is-hit, w: metallic
+[[vk::binding(7, 1)]] RWTexture2D<float4> gRadiance;          // rgb: this-frame mean radiance
+[[vk::binding(8, 1)]] RWTexture2D<float4> gNormalDepth;       // xyz: world normal, w: view-space linear z
+[[vk::binding(9, 1)]] RWTexture2D<float4> gAlbedoObj;         // rgb: base color, w: object id
+[[vk::binding(10, 1)]] RWTexture2D<float4> gMotion;           // xy: screen motion vector, z: is-hit, w: metallic
 [[vk::binding(11, 1)]] RWTexture2D<float4> gRadianceSpecular; // rgb: this-frame specular-lobe radiance
 [[vk::binding(12, 1)]] RWTexture2D<float4> gSpecAlbedo;       // rgb: pre-integrated specular BRDF (demod factor)
 
@@ -68,8 +68,7 @@ float3 SampleSkyLight(float3 direction)
 {
     if (sky_light.has_sky_map != 0)
     {
-        float3 light =
-            skyMap.SampleLevel(skyMapSampler, direction, 0).rgb;
+        float3 light = skyMap.SampleLevel(skyMapSampler, direction, 0).rgb;
 
         return light;
     }
@@ -149,7 +148,8 @@ float3 SampleSkyLight(Intersection intersection, MaterialParameters mat_param, f
     // evaluate brdf, split into diffuse/specular lobes (the denoiser demodulates them separately)
     float3 diffuse_radiance;
     float3 specular_radiance;
-    float3 radiance = CalculateDirectLightingSplit(w_o, w_i, light_sample, surface, diffuse_radiance, specular_radiance);
+    float3 radiance =
+        CalculateDirectLightingSplit(w_o, w_i, light_sample, surface, diffuse_radiance, specular_radiance);
 
     float weight = SaturateDot(w_i, intersection.normal) / (out_pdf + Eps);
     specular_out = specular_radiance * weight;
@@ -392,8 +392,8 @@ float3 SamplePixel(RayDesc ray_desc, out float3 out_specular, out float out_diff
 
         if (bounce == 1)
         {
-            first_hit_dist = (ray_query.CommittedStatus() == COMMITTED_TRIANGLE_HIT) ? ray_query.CommittedRayT()
-                                                                                     : ray_desc.TMax;
+            first_hit_dist =
+                (ray_query.CommittedStatus() == COMMITTED_TRIANGLE_HIT) ? ray_query.CommittedRayT() : ray_desc.TMax;
         }
 
         // terminal condition: hit sky
@@ -613,9 +613,7 @@ float3 ComputeFrameRadiance(uint2 pixel, uint seed, float2 pixel_size, out float
     return this_samples / float(spp);
 }
 
-[shader("compute")]
-[numthreads(16, 16, 1)] void shader_main(uint3 DTid
-                                         : SV_DispatchThreadID) {
+[shader("compute")][numthreads(16, 16, 1)] void shader_main(uint3 DTid : SV_DispatchThreadID) {
     uint2 pixel = uint2(DTid.xy);
 
     // bound check

--- a/tests/nrd/NrdProbeTest.mm
+++ b/tests/nrd/NrdProbeTest.mm
@@ -31,10 +31,9 @@ public:
         }
 
         const nrd::LibraryDesc &lib = *nrd::GetLibraryDesc();
-        Log(Info, "{}: NRD v{}.{}.{} spirvOffsets s={} b={} u={} t={}", GetName(), lib.versionMajor,
-            lib.versionMinor, lib.versionBuild, lib.spirvBindingOffsets.samplerOffset,
-            lib.spirvBindingOffsets.constantBufferOffset, lib.spirvBindingOffsets.storageTextureAndBufferOffset,
-            lib.spirvBindingOffsets.textureOffset);
+        Log(Info, "{}: NRD v{}.{}.{} spirvOffsets s={} b={} u={} t={}", GetName(), lib.versionMajor, lib.versionMinor,
+            lib.versionBuild, lib.spirvBindingOffsets.samplerOffset, lib.spirvBindingOffsets.constantBufferOffset,
+            lib.spirvBindingOffsets.storageTextureAndBufferOffset, lib.spirvBindingOffsets.textureOffset);
 
         NrdCookedShaders cooked;
         if (!cooked.Load())
@@ -63,8 +62,7 @@ public:
         for (uint32_t i = 0; i < desc.pipelinesNum; i++)
         {
             RHINrdBackend::CookedPipeline pipeline;
-            if (!cooked.BuildPipeline(desc.pipelines[i].shaderIdentifier, pipeline) ||
-                !backend.AddPipeline(pipeline))
+            if (!cooked.BuildPipeline(desc.pipelines[i].shaderIdentifier, pipeline) || !backend.AddPipeline(pipeline))
             {
                 Log(Error, "{}: [{:2}] {} failed", GetName(), i, desc.pipelines[i].shaderIdentifier);
             }


### PR DESCRIPTION
Implements the "format and style check pipeline" item from docs/TODO.md.

## What's added

- **`dev/check_format.py`** — single entry point that checks (or fixes with `--fix`) all git-tracked sources (thirdparty excluded) against the project formatters:
  - c++/objc/slang: clang-format (pinned 22.1.5 in CI; majors 18–22 verified byte-identical on this codebase)
  - python: autopep8, now configured via `pyproject.toml` (`max_line_length = 120`)
  - markdown: markdownlint via npx, using the existing `.markdownlint.json`
- **`format` job in ci.yml** — runs unconditionally on every push/PR (it's cheap and also covers files outside the code paths filter, e.g. docs) and gates the final `ci` job.
- **Docs** — new Format Check section in docs/CI.md, pointer in docs/CONTRIBUTING.md, TODO item checked off.

## Existing drift fixed

The codebase had drifted from its own formatter configs: 18 c++/objc files, 5 slang shaders, 3 python scripts, and 2 markdown issues. Fixed mechanically with `check_format.py --fix` so this check is green from day one. The only non-whitespace changes are alphabetical include re-sorts in `RHI.cpp` and `ray_trace.h.slang` (all affected headers are include-guarded), plus a `text` language tag on the docs/Nrd.md architecture diagram.

## Local usage

```bash
python3 dev/check_format.py          # check only, exit 1 on violations
python3 dev/check_format.py --fix    # rewrite files in place
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5FJiDCCvQiwTKxWFAiYAK

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5FJiDCCvQiwTKxWFAiYAK)_