### PR TITLE
[GPU] build BSDF shading basis once per evaluation

### DIFF
--- a/shaders/include/ray_trace.h.slang
+++ b/shaders/include/ray_trace.h.slang
@@ -107,7 +107,9 @@ float3 BxdfMetal(float3 w_o, out float3 w_i, out float out_pdf, out bool is_spec
                  Intersection intersection)
 {
     // enter tangent space
-    float3 local_w_o = normalize(TransformBasisToLocal(w_o, intersection.normal, intersection.tangent.xyz));
+    float3 axis_u, axis_v, axis_w;
+    GetLocalAxisFromNormal(intersection.normal, intersection.tangent.xyz, axis_u, axis_v, axis_w);
+    float3 local_w_o = normalize(TransformBasisToLocal(w_o, axis_u, axis_v, axis_w));
 
     // try specular first. it may be the result of
     // 1. all metal reflection
@@ -122,7 +124,7 @@ float3 BxdfMetal(float3 w_o, out float3 w_i, out float out_pdf, out bool is_spec
     }
 
     // back to world space
-    w_i = normalize(TransformBasisToWorld(result.local_w_i, intersection.normal, intersection.tangent.xyz));
+    w_i = normalize(TransformBasisToWorld(result.local_w_i, axis_u, axis_v, axis_w));
     out_pdf = result.pdf;
 
     return result.throughput;
@@ -135,7 +137,9 @@ float3 BxdfDieletric(float3 w_o, out float3 w_i, out float out_pdf, out bool is_
     is_specular_lobe = true;
 
     // enter tangent space
-    float3 local_w_o = normalize(TransformBasisToLocal(w_o, intersection.normal, intersection.tangent.xyz));
+    float3 axis_u, axis_v, axis_w;
+    GetLocalAxisFromNormal(intersection.normal, intersection.tangent.xyz, axis_u, axis_v, axis_w);
+    float3 local_w_o = normalize(TransformBasisToLocal(w_o, axis_u, axis_v, axis_w));
     float3 local_w_i;
 
     // Perfect dielectric materials
@@ -161,7 +165,7 @@ float3 BxdfDieletric(float3 w_o, out float3 w_i, out float out_pdf, out bool is_
     }
 
     // back to world space
-    w_i = normalize(TransformBasisToWorld(local_w_i, intersection.normal, intersection.tangent.xyz));
+    w_i = normalize(TransformBasisToWorld(local_w_i, axis_u, axis_v, axis_w));
 
     return mat_param.base_color;
 }


### PR DESCRIPTION
## Summary

Both `BxdfMetal` and `BxdfDieletric` transformed `w_o` into tangent space and `w_i` back to world, and each transform internally rebuilt the **same** orthonormal basis (`GetLocalAxisFromNormal`, 2 cross + 1 normalize) from the normal/tangent. Build the basis once and reuse it for both transforms.

## Nature of the change
- **Quality: neutral.** Algebraically identical (same u,v,w). All 4 NRD gates pass, including the bit-exact converged-flicker assertion; firefly count 16→18 (limit 100) reflects only ULP-level FP recompilation.
- **Perf: neutral (measured).** Trace 16.2 vs 15.9 ms — within noise. The trace is memory/traversal-bound (confirmed by a prior 16×16 vs 8×8 threadgroup A/B), so removing this ALU is hidden behind memory latency. This is a redundancy cleanup, not a framerate win; it would only pay off if the kernel became ALU-bound.

## Testing
`tests/nrd/run_nrd_gates.py` — ALL PASS (converged flicker 0.0003, firefly 18, motion yaw 0.0073, pitch 0.0049), on the real GPU pipeline.