### PR TITLE
[Build] remove obsolete C++ warning exclusions and document the live ones

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,16 +122,13 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         /wd4714                         # function marked as __forceinline not inlined: we understand inline is just a suggestion
         )
 else()
-    # -Weverything is intentional: clang-cl (the windows glfw framework) maps -Wall to -Weverything,
-    # so windows has always built against the full warning set. Making it explicit keeps every
-    # platform on the same surface, so regressions fail on the first build anywhere instead of
-    # only in the windows CI job.
+    # note: clang-cl (the windows glfw framework) maps -Wall to -Weverything, so exclusions below
+    # that -Wall/-Wextra/-Wpedantic never enable are still load-bearing for windows builds.
     target_compile_options(sparkle PRIVATE
-        -Weverything
+        -Wall
         -Wextra
         -Wpedantic
         -Werror
-        -Wno-unknown-warning-option     # clang versions differ across platforms (apple/ndk/clang-cl/clang-tidy); newer -Wno flags below must not error on older clang
         -Wno-c++98-compat               # we are targeting c++20
         -Wno-c++98-compat-pedantic      # we are targeting c++20
         -Wno-c++20-compat               # fires on c++20-only constructs (e.g. implicit typename), which we use freely
@@ -143,11 +140,6 @@ else()
         -Wno-unsafe-buffer-usage        # fires on nearly all pointer arithmetic, not practical for a renderer
         -Wno-global-constructors        # self-registering globals (e.g. ConfigValue) are used by design
         -Wno-exit-time-destructors      # same reason as -Wno-global-constructors
-        -Wno-padded                     # compiler-inserted padding is fine for cpu-side structs; gpu structs align explicitly
-        -Wno-weak-vtables               # requiring key functions everywhere is not worth it (ms abi lacks the concept entirely)
-        -Wno-thread-safety-negative     # negative capability annotations are too invasive; basic thread-safety analysis stays on
-        -Wno-missing-include-dirs       # the xcode generator lists derived-source include dirs that do not exist yet
-        -Wno-nrvo                       # clang 22+: informational note about missed copy elision, not a defect
         )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ else()
         -Werror
         -Wno-c++98-compat               # we are targeting c++20
         -Wno-c++98-compat-pedantic      # we are targeting c++20
+        -Wno-c++20-compat               # fires on c++20-only constructs (e.g. implicit typename), which we use freely
         -Wno-extra-semi-stmt            # not that necessary
         -Wno-unused-macros              # GlobalMacro.h is force-included everywhere, but most files use only a few of its macros
         -Wno-covered-switch-default     # contradicts -Wswitch-default: a fully covered switch must still have a default case

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ else()
         -Wextra
         -Wpedantic
         -Werror
+        -Wno-unknown-warning-option     # clang versions differ across platforms (apple/ndk/clang-cl/clang-tidy); newer -Wno flags below must not error on older clang
         -Wno-c++98-compat               # we are targeting c++20
         -Wno-c++98-compat-pedantic      # we are targeting c++20
         -Wno-c++20-compat               # fires on c++20-only constructs (e.g. implicit typename), which we use freely
@@ -142,6 +143,11 @@ else()
         -Wno-unsafe-buffer-usage        # fires on nearly all pointer arithmetic, not practical for a renderer
         -Wno-global-constructors        # self-registering globals (e.g. ConfigValue) are used by design
         -Wno-exit-time-destructors      # same reason as -Wno-global-constructors
+        -Wno-padded                     # compiler-inserted padding is fine for cpu-side structs; gpu structs align explicitly
+        -Wno-weak-vtables               # requiring key functions everywhere is not worth it (ms abi lacks the concept entirely)
+        -Wno-thread-safety-negative     # negative capability annotations are too invasive; basic thread-safety analysis stays on
+        -Wno-missing-include-dirs       # the xcode generator lists derived-source include dirs that do not exist yet
+        -Wno-nrvo                       # clang 22+: informational note about missed copy elision, not a defect
         )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,10 +122,12 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         /wd4714                         # function marked as __forceinline not inlined: we understand inline is just a suggestion
         )
 else()
-    # note: clang-cl (the windows glfw framework) maps -Wall to -Weverything, so exclusions below
-    # that -Wall/-Wextra/-Wpedantic never enable are still load-bearing for windows builds.
+    # -Weverything is intentional: clang-cl (the windows glfw framework) maps -Wall to -Weverything,
+    # so windows has always built against the full warning set. Making it explicit keeps every
+    # platform on the same surface, so regressions fail on the first build anywhere instead of
+    # only in the windows CI job.
     target_compile_options(sparkle PRIVATE
-        -Wall
+        -Weverything
         -Wextra
         -Wpedantic
         -Werror

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         /wd4714                         # function marked as __forceinline not inlined: we understand inline is just a suggestion
         )
 else()
+    # note: clang-cl (the windows glfw framework) maps -Wall to -Weverything, so exclusions below
+    # that -Wall/-Wextra/-Wpedantic never enable are still load-bearing for windows builds.
     target_compile_options(sparkle PRIVATE
         -Wall
         -Wextra
@@ -129,17 +131,14 @@ else()
         -Werror
         -Wno-c++98-compat               # we are targeting c++20
         -Wno-c++98-compat-pedantic      # we are targeting c++20
-        -Wno-c99-extensions             # we are targeting c++20
-        -Wno-c++20-compat               # we are targeting c++20
         -Wno-extra-semi-stmt            # not that necessary
-        -Wno-unused-macros              # too much false alerts
-        -Wno-covered-switch-default     # -Wswitch-default has already provided enough protection
+        -Wno-unused-macros              # GlobalMacro.h is force-included everywhere, but most files use only a few of its macros
+        -Wno-covered-switch-default     # contradicts -Wswitch-default: a fully covered switch must still have a default case
         -Wno-switch-enum                # it is not always possible to list all enums (especially for vulkan enums)
-        -Wno-cast-function-type-strict  # TODO: remove later
-        -Wno-unsafe-buffer-usage        # TODO: remove later
-        -Wno-global-constructors        # TODO: remove later
-        -Wno-exit-time-destructors      # TODO: remove later
-        -Wno-unknown-pragmas            # TODO: remove later
+        -Wno-cast-function-type-strict  # vulkan function loading casts PFN_vkVoidFunction to concrete PFN_* types by design
+        -Wno-unsafe-buffer-usage        # fires on nearly all pointer arithmetic, not practical for a renderer
+        -Wno-global-constructors        # self-registering globals (e.g. ConfigValue) are used by design
+        -Wno-exit-time-destructors      # same reason as -Wno-global-constructors
         )
 endif()
 

--- a/libraries/include/core/GlobalMacro.h
+++ b/libraries/include/core/GlobalMacro.h
@@ -57,6 +57,15 @@
 
 #pragma endregion
 
+#pragma region Graphics API Macros
+
+// defined by the build system on platforms that use the corresponding graphics api
+#ifndef ENABLE_VULKAN
+#define ENABLE_VULKAN 0
+#endif
+
+#pragma endregion
+
 #pragma region Platform Sanity Check
 
 #if PLATFORM_MACOS

--- a/libraries/include/core/Logger.h
+++ b/libraries/include/core/Logger.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if _MSC_VER
+#ifdef _MSC_VER
 // to make msvc happy...
 #define FMT_USE_NONTYPE_TEMPLATE_ARGS 0
 #endif

--- a/libraries/source/renderer/RenderConfig.cpp
+++ b/libraries/source/renderer/RenderConfig.cpp
@@ -143,7 +143,8 @@ void RenderConfig::Validate()
         int back_buffer_width;
         int back_buffer_height;
         view_->GetFrameBufferSize(back_buffer_width, back_buffer_height);
-        image_width = image_height * (static_cast<float>(back_buffer_width) / back_buffer_height);
+        const float aspect_ratio = static_cast<float>(back_buffer_width) / static_cast<float>(back_buffer_height);
+        image_width = static_cast<uint32_t>(static_cast<float>(image_height) * aspect_ratio);
         config_width.Set(image_width);
 
         Log(Info, "View size [{}, {}]", image_width, image_height);


### PR DESCRIPTION
## Summary

Audits the clang warning-exclusion block in `CMakeLists.txt`: removes two exclusions that no longer suppress anything and rewrites the comments on the rest to state their real justification (replacing the `TODO: remove later` comments that turned out not to be removable). Also keeps three small code fixes surfaced by a `-Weverything` experiment that was tried on this branch and reverted.

### Removed exclusions

- `-Wno-c99-extensions` — nothing in the codebase uses C99 extensions (no compound literals, no flexible array members; VLAs are diagnosed by a separate flag that this exclusion never covered). The old comment ("we are targeting c++20") was unrelated to what the flag does.
- `-Wno-unknown-pragmas` — resolves its TODO. Every supported compiler is clang-based (Apple clang, NDK clang, clang-cl), and all pragmas in use (`once`, `region`/`endregion`, `GCC diagnostic`, `clang diagnostic`) are recognized by clang, verified with clang 18. Real MSVC (`glfw-sln`) still needs `#pragma clang`/`GCC` suppressed, so `/wd4068` stays in the MSVC branch.

### Kept exclusions, with corrected comments

The key non-obvious fact, now recorded as a comment in the block: clang-cl (the windows `glfw` framework, which takes the same `else()` branch) maps `-Wall` to `-Weverything`, so most of these exclusions are load-bearing on windows even though `-Wall -Wextra -Wpedantic` never enables them under plain clang.

- `-Wno-c++20-compat` — initially removed as inert at `-std=c++20`, but windows CI proved otherwise: under `-Weverything` it fires *in* C++20 mode on C++20-only constructs (implicit `typename`, e.g. `RHIPIpelineState.h`). Restored with an accurate comment.
- `-Wno-cast-function-type-strict` — Vulkan function loading casts `PFN_vkVoidFunction` to concrete `PFN_*` types by design.
- `-Wno-global-constructors` / `-Wno-exit-time-destructors` — self-registering globals (e.g. the `ConfigValue` pattern) are used by design.
- `-Wno-unsafe-buffer-usage` — fires on nearly all pointer arithmetic; not practical for a renderer.
- `-Wno-covered-switch-default` — directly contradicts `-Wswitch-default` (both in `-Weverything`); one of the two must be disabled.
- `-Wno-unused-macros` — `GlobalMacro.h` is force-included into every TU, but most files use only a few of its macros.

### The -Weverything experiment (tried, reverted)

Making `-Weverything` explicit on all platforms was attempted to give every platform the same warning surface windows already has. It was reverted: each platform's clang surfaced a different warning set (MS ABI gaps like `-Wweak-vtables`, Xcode generator quirks like `-Wmissing-include-dirs`, version-skew flags like `-Wnrvo` that then require `-Wno-unknown-warning-option`), making the suppression list open-ended. The genuine issues it found are kept as code fixes:

- `Logger.h`: `#if _MSC_VER` → `#ifdef _MSC_VER` (found by `-Wundef`)
- `RenderConfig.cpp`: implicit int/float conversions in the mobile view-size calculation made explicit (found by `-Wfloat-conversion` / `-Wimplicit-int-float-conversion`)
- `GlobalMacro.h`: `ENABLE_VULKAN` now defaults to 0 like the other build macros, so `#if ENABLE_VULKAN` is well-defined on metal platforms (found by `-Wundef`)

## Testing

- Verified with clang 18 / clang-cl 18 on isolated test cases: the removed flags suppress nothing this codebase triggers, and `clang-cl -Wall` behaves as `-Weverything`.
- Full validation via the CI build matrix; the windows clang-cl jobs are the ones that exercise the implicit `-Weverything` surface.