### PR TITLE
[Build] stage-scoped setup, and split run.py from build.py

### DIFF
--- a/.github/actions/build-platform/action.yml
+++ b/.github/actions/build-platform/action.yml
@@ -76,7 +76,7 @@ runs:
       shell: bash
       env:
         SPARKLE_BUILD_JOBS: 8
-      run: python3 build.py --framework ${{ inputs.framework }} --config ${{ inputs.build-type }} --archive ${{ steps.setup-environment.outputs.build-args }}
+      run: python3 build.py --framework ${{ inputs.framework }} --config ${{ inputs.build-type }} --stage build --stage package ${{ steps.setup-environment.outputs.build-args }}
 
     - name: Check Android task graph
       if: inputs.framework == 'android' && inputs.build-type == 'Debug'

--- a/.github/actions/wait-for-job/action.yml
+++ b/.github/actions/wait-for-job/action.yml
@@ -14,8 +14,10 @@ runs:
         JOB_NAME: ${{ inputs.job-name }}
       run: |
         for _ in $(seq 1 90); do
+          # a transient API error (e.g. a 503) is "still waiting", never a verdict
           conclusion=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
-            --jq "[.jobs[] | select(.name | endswith(\"$JOB_NAME\")) | .conclusion // \"\"][0]")
+            --jq "[.jobs[] | select(.name | endswith(\"$JOB_NAME\")) | .conclusion // \"\"][0]" 2>/dev/null) \
+            || { echo "status poll failed (transient API error), retrying"; conclusion=""; }
           case "$conclusion" in
             success) exit 0 ;;
             failure|cancelled|timed_out|skipped) echo "$JOB_NAME concluded: $conclusion"; exit 1 ;;

--- a/build.py
+++ b/build.py
@@ -226,15 +226,24 @@ def run_git_submodule_update():
     )
 
 
-def setup():
-    from resources.setup import setup_resources
-    from ide.setup import setup_ide
+def setup(args):
+    """Stage-scoped setup: each step exists to feed a specific stage, so invocations
+    that skip the stage skip the step (e.g. CI cook and test nodes, which never
+    compile, skip the recursive submodule clone)."""
+    compiling = ("build" in args["stages"] or args["generate_only"]
+                 or args["configure_only"] or args["clangd"])
 
-    run_git_submodule_update()
-    setup_resources()
-    setup_ide()
+    if compiling:
+        run_git_submodule_update()
 
-    print("Setup complete.")
+    # the build embeds resources/packed into the product and the cook stage images it
+    if compiling or "cook" in args["stages"]:
+        from resources.setup import setup_resources
+        setup_resources()
+
+    if compiling:
+        from ide.setup import setup_ide
+        setup_ide()
 
 
 def product_name(framework, config, extension):
@@ -349,7 +358,7 @@ def main():
 
     args = parse_args()
 
-    setup()
+    setup(args)
 
     check_environment(args)
 

--- a/build.py
+++ b/build.py
@@ -76,29 +76,19 @@ def assemble_cooked_image(cooker):
     print(f"Assembled cooked content image at {image_dir}")
 
 
-def resolve_stages(stage_args, skip_build, cook, archive, framework):
-    """Stage selection: explicit --stage wins, then legacy flags; the default is
-    build + cook (cooked content is always wanted; hosts that cannot cook for the
-    target build without it), plus package for device frameworks (a device only
-    receives cooked content through its installed package)."""
+def resolve_stages(stage_args, framework):
+    """Stage selection: explicit --stage wins; the default is every stage the host
+    supports for the target — the full pipeline, minus cook on hosts that cannot
+    produce a cooker binary. Explicit selections (including 'all') never degrade:
+    a missing capability fails fast in validate_stages."""
     if stage_args:
         selected = set()
         for stage in stage_args:
             selected |= set(STAGES) if stage == "all" else {stage}
-    elif skip_build or cook or archive:
-        selected = set()
-        if not skip_build:
-            selected.add("build")
-        if cook:
-            selected.add("cook")
-        if archive:
-            selected.add("package")
     else:
-        selected = {"build"}
+        selected = {"build", "package"}
         if cooker_framework(framework) is not None:
             selected.add("cook")
-        if framework in DEVICE_FRAMEWORKS:
-            selected.add("package")
     return [stage for stage in STAGES if stage in selected]
 
 
@@ -144,10 +134,8 @@ def parse_args(args=None):
     parser.add_argument("--stage", action="append",
                         choices=["build", "cook", "package", "all"],
                         help="Pipeline stage(s) to run in canonical order build -> cook -> package;"
-                        " repeat to select multiple. Default: build + cook. Cross-compiled"
-                        " frameworks cook through the host framework's binary")
-    parser.add_argument("--archive", action="store_true",
-                        help="Alias for the package stage (build + package)")
+                        " repeat to select multiple. Default: every stage the host supports."
+                        " Cross-compiled frameworks cook through the host framework's binary")
     parser.add_argument("--cooked",
                         help="Cooked content image directory for the package stage"
                         " (default: the host cooker's assembled image)")
@@ -163,12 +151,6 @@ def parse_args(args=None):
                         help="Run the build's configure step (fetches dependencies) without building")
     parser.add_argument("--clangd", action="store_true",
                         help="Generate compile_commands.json for clangd")
-    parser.add_argument("--cook", action="store_true",
-                        help="Alias for the cook stage (build + cook; with --skip_build: cook only)")
-    parser.add_argument("--run", action="store_true",
-                        help="Run the built executable after building")
-    parser.add_argument("--skip_build", action="store_true",
-                        help="Do every thing but skip building")
     parser.add_argument("--strip_test", action="store_true",
                         help="Disable test case support (enabled by default)")
     parser.add_argument("--clean", action="store_true",
@@ -179,15 +161,13 @@ def parse_args(args=None):
     parser.add_argument("--cmake-args",
                         help="Additional CMake arguments (e.g., --cmake-args='-DCMAKE_EXE_LINKER_FLAGS=\"-lc++abi\"')")
 
-    # Unknown args will be used for --run the built executable
+    # Unknown args pass through to the app (cook stage runs and run.py launches)
     parsed_args, unknown_args = parser.parse_known_args(args)
 
     return {
         "framework": parsed_args.framework,
         "config": parsed_args.config,
-        "stages": resolve_stages(parsed_args.stage, parsed_args.skip_build,
-                                 parsed_args.cook, parsed_args.archive, parsed_args.framework),
-        "run": parsed_args.run,
+        "stages": resolve_stages(parsed_args.stage, parsed_args.framework),
         "cooked": parsed_args.cooked,
         "cmake_options": construct_additional_cmake_options(parsed_args, parsed_args.cmake_args),
         "unknown_args": unknown_args,
@@ -345,12 +325,6 @@ def build_project(args):
 
     if "package" in stages:
         package_project(builder, args)
-
-    if args["run"]:
-        print("Running...")
-        exit_code = builder.run(args)
-        if exit_code is not None and exit_code != 0:
-            sys.exit(exit_code)
 
 
 def main():

--- a/dev/run_tests.py
+++ b/dev/run_tests.py
@@ -32,8 +32,10 @@ def venv_python():
 
 
 def build_command(framework, config):
+    # explicit stages: the suite needs a runnable build with cooked content, not a package
     return [sys.executable, os.path.join(REPO, "build.py"),
-            "--framework", framework, "--config", config]
+            "--framework", framework, "--config", config,
+            "--stage", "build", "--stage", "cook"]
 
 
 def preflight_steps():
@@ -51,8 +53,8 @@ def app_command(framework, config, software, test_case, test_args):
         command = [sys.executable, os.path.join(
             REPO, "dev", "run_without_gpu.py")]
     else:
-        command = build_command(framework, config)
-        command += ["--skip_build", "--run"]
+        command = [sys.executable, os.path.join(REPO, "run.py"),
+                   "--framework", framework, "--config", config, "--skip_build"]
     return command + ["--test_case", test_case] + list(test_args)
 
 

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -128,7 +128,7 @@ python3 build.py --framework glfw --generate_only
 # make an Android APK debug apk and run on a connected device
 $env:VULKAN_SDK='D:/SDKs/VulkanSDK/1.4.350.0'
 $env:ANDROID_HOME='D:/SDKs/AndroidSDK'
-python3 build.py --framework android --run
+python3 run.py --framework android
 ```
 
 ``` shell
@@ -148,7 +148,7 @@ python3 build.py --framework ios --apple_auto_sign --generate_only
 # make an iOS release build and run on a connected device in ray tracing mode
 export VULKAN_SDK=/Users/username/VulkanSDK/1.4.350.0
 export APPLE_DEVELOPER_TEAM_ID=ABC123DEF4
-python3 build.py --framework ios --apple_auto_sign --run --pipeline gpu
+python3 run.py --framework ios --apple_auto_sign --pipeline gpu
 ```
 
 ### Build via Script
@@ -156,8 +156,11 @@ python3 build.py --framework ios --apple_auto_sign --run --pipeline gpu
 **All platforms:**
 
 ``` shell
-python3 build.py --framework=<framework> [build-options] [run-options]
+python3 build.py --framework=<framework> [build-options]   # pipeline: build, cook, package
+python3 run.py --framework=<framework> [build-options] [app-options]   # build for a run, then launch
 ```
+
+`build.py` is the pipeline: it produces artifacts and never launches the app. `run.py` is the launcher: it runs the stages a launch consumes (build, cook, and for device frameworks package, whose product the run installs), then launches the app, forwarding unrecognized options to it. `run.py --skip_build` launches the existing binary without running any stage.
 
 **Supported frameworks:**
 
@@ -178,26 +181,24 @@ The host machine (where build.py runs) and the target framework (what is built, 
 | `android`        | ✔     | ✔       | ✔     |
 
 * `macos`/`ios` need Xcode, so they build only on a macOS host. `glfw` always targets the host's own desktop OS (there is no cross-OS desktop build), so a Windows glfw package can only come from a Windows host.
-* The cook stage runs on any host through the host's own framework binary (`macos` on macOS, `glfw` on Windows) regardless of the target — cooked content is target-independent. A Linux host can build for android but cannot cook for it: no supported framework produces a cooker binary on Linux, so android there defaults to build only and packages cooked content produced elsewhere (`--cooked`).
+* The cook stage runs on any host through the host's own framework binary (`macos` on macOS, `glfw` on Windows) regardless of the target — cooked content is target-independent. A Linux host can build for android but cannot cook for it: no supported framework produces a cooker binary on Linux, so android there defaults to build + package and packages cooked content produced elsewhere (`--cooked`).
 * Product archives are named by target (`android-Release.apk`, `macos-Release.zip`); only glfw carries the host system in its name (`windows-glfw-Release.zip`), because its target is the host's own desktop OS.
 
 **Pipeline stages:**
 
-The pipeline is three stages, selected with `--stage` (repeatable) and run in canonical order build → cook → package. The default is build + cook, plus package for the device frameworks (`android`, `ios`): cooked content is always wanted, and a warm cook costs only artifact lookups, so the plain `build.py --config Release --run` loop runs against cooked content on every framework. Desktop runs read the cook output from the build tree directly; a device only receives cooked content through its installed package, which is why the device default includes the package stage. `--stage all` produces a complete distributable locally: a built app, cooked content (see [Cooking.md](Cooking.md)), and a product archive whose packed content is the cooked image.
+The pipeline is three stages, selected with `--stage` (repeatable) and run in canonical order build → cook → package. The default is every stage the host supports: a plain `build.py` produces a complete distributable — a built app, cooked content (see [Cooking.md](Cooking.md)), and a product archive whose packed content is the cooked image — minus the cook stage on hosts that cannot produce a cooker binary. Explicit selections (including `--stage all`) never degrade; a missing capability fails fast instead. The development loop is `run.py`, which selects only the stages a launch consumes: build + cook (cooked content is always wanted, and a warm cook costs only artifact lookups; desktop runs read the cook output from the build tree directly), plus package for the device frameworks (`android`, `ios`) because a device only receives cooked content through its installed package.
 
 * Each stage is idempotent through its own cache (incremental compile, hit-or-cook artifacts, archive from current inputs) and fails fast when an input from an earlier stage is missing — it never runs an upstream stage implicitly.
 * Cooked content is shared across targets, and the cooker lives in the sparkle binary — so cooking for a cross-compiled framework (`android`, `ios`) executes the host framework's binary (`macos` on a Mac, `glfw` elsewhere) and fails with a hint if that binary is not built yet. The cook stage assembles its output into a self-contained content image at `build_system/<cooker>/output/cooked_image`, which the package stage picks up automatically (`--cooked <dir>` overrides).
-* The cook stage logs to its own file (`logs/cook.log` under the app's external log directory) via the app's `--log_path` argument, so a later `--run` never overwrites the cook log. `--log_path` is honored by desktop builds only.
+* The cook stage logs to its own file (`logs/cook.log` under the app's external log directory) via the app's `--log_path` argument, so a later run never overwrites the cook log. `--log_path` is honored by desktop builds only.
 * `package` replaces the archive's asset tree with the content image (compiled shaders stay build-owned), strips the app's internal runtime state, and warns when no image is available. That package still works: each cook job falls back to raw assets and cooks at runtime — the fallback is per job, never a packaging policy.
 * Rewriting a signature-sealed package breaks its signature, so the package stage re-signs afterwards: apk with zipalign + apksigner and the debug key gradle signs with, ipa with the identity that signed the build. CI release nodes do the same for their published packages.
-* `--run` on a device framework installs the product package when the package stage ran in the same invocation; with an explicit stage selection that skips packaging, it installs the raw build output, which cooks on the fly. The android run reports the device's cook activity after pulling its log.
-* `--archive` and `--cook` remain as stage aliases: `--archive` = build+package, `--cook` = build+cook, and `--skip_build` drops the build stage.
+* `run.py` on a device framework installs the product package its own package stage produced; with `--skip_build` it installs the raw build output, which cooks on the fly. The android run reports the device's cook activity after pulling its log.
 
 **Common build options:**
 
 * `--config=Release` - Release build (default: Debug).
-* `--stage=<build|cook|package|all>` - Select pipeline stage(s), see above.
-* `--archive` - Archive the app for distribution (alias for the package stage). Not required if you test the build locally. The archived app is located in `build_system/<framework>/product`.
+* `--stage=<build|cook|package|all>` - Select pipeline stage(s), see above (build.py only). The package stage's product archive lands in `build_system/<framework>/product`.
 * `--generate_only` - Generate IDE project files without building.
 * `--clangd` - Generate compile_commands.json for clangd intellisense support.
 * `--profile` - Enable Tracy profiler.
@@ -207,7 +208,7 @@ The pipeline is three stages, selected with `--stage` (repeatable) and run in ca
 * `--apple_auto_sign` - Enable automatic code signing for Apple platforms. Requires APPLE_DEVELOPER_TEAM_ID to be set. See [this page](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/)
 * `--cmake-args='...'` - Pass extra arguments to CMake, e.g. `--cmake-args='-DENABLE_LTO=ON'` to enable link time optimization for a distribution build (off by default: it adds minutes of Release link time).
 * `--help` - Show all usage help.
-* `--run` - Run after building. For mobile builds, it tries to run on a connected device.
+* `--skip_build` - (run.py only) Launch the existing binary without running any pipeline stage. For mobile builds, the run installs on a connected device.
 
 ### Troubleshooting
 

--- a/docs/Cooking.md
+++ b/docs/Cooking.md
@@ -2,7 +2,7 @@
 
 Cooking moves deterministic asset work out of the frame loop: a cook job transforms source data into a validated disk artifact once, and every later run loads the artifact.
 
-Day to day it is automatic. The default `build.py` invocation runs the cook stage after building (see [Build.md](Build.md) for stage selection, host/target rules and packaging), and at runtime a missing artifact cooks on the fly while the requester shows its pending state. Artifacts live in the app's internal storage under `cooked/` (`sparkle.app/Contents/SharedSupport/cooked` for macos, `build/generated/cooked` for glfw); delete that directory or run the app with `--rebuild_cache true` to force a recook. Cook stage runs log to `logs/cook.log` next to the regular app logs. Device frameworks (`android`, `ios`) cannot read the host's cook output at runtime, so their default invocation also packages: the product's asset tree is replaced with the cooked content image, the package is re-signed, and `--run` installs that product — the device then reads the packaged artifacts instead of cooking on the fly.
+Day to day it is automatic. `run.py` and the default `build.py` invocation run the cook stage after building (see [Build.md](Build.md) for stage selection, host/target rules and packaging), and at runtime a missing artifact cooks on the fly while the requester shows its pending state. Artifacts live in the app's internal storage under `cooked/` (`sparkle.app/Contents/SharedSupport/cooked` for macos, `build/generated/cooked` for glfw); delete that directory or run the app with `--rebuild_cache true` to force a recook. Cook stage runs log to `logs/cook.log` next to the regular app logs. Device frameworks (`android`, `ios`) cannot read the host's cook output at runtime, so a `run.py` launch for them also packages: the product's asset tree is replaced with the cooked content image, the package is re-signed, and the run installs that product — the device then reads the packaged artifacts instead of cooking on the fly.
 
 ## Architecture
 
@@ -48,7 +48,7 @@ The CPU jobs port the cook shaders one-to-one ([libraries/include/renderer/resou
 The `ibl_parity` test case enforces this: it deletes the internal IBL artifacts, lets the GPU cook them, runs the CPU jobs and compares (rgb only — the alpha channel is producer-dependent and no consumer reads it). It is deliberately not a CI gate — the CPU reference cook costs ~15 runner-minutes, and once a CI node cooks through the CPU jobs the screenshot gates cover divergence end to end. It runs as part of the local macos suite (its coverage in tests/coverage.json is macos-only — a software rasterizer would compare CPU to CPU — and its `recooks` mark makes the suite drop it under `--require_cooked`, whose gate its deliberate recook would trip; see [Test.md](Test.md)) or standalone:
 
 ```bash
-python3 build.py --framework macos --config Release --run --test_case ibl_parity --headless true
+python3 run.py --framework macos --config Release --test_case ibl_parity --headless true
 ```
 
 On failure it writes both payloads to internal storage under `cooked_debug/` for offline analysis. Measured on Apple M-series: `ibl_brdf` max error is one half ULP; the env maps stay under 0.05 against a clamp ceiling of 10.

--- a/docs/Run.md
+++ b/docs/Run.md
@@ -2,7 +2,7 @@
 
 ## Launching
 
-Always run the app through `build.py --run` during development for robustness; do not run built binaries directly. See [Build.md](Build.md) for build and run commands.
+Always run the app through `run.py` during development for robustness; do not run built binaries directly. See [Build.md](Build.md) for build and run commands.
 
 ## File System
 

--- a/docs/Test.md
+++ b/docs/Test.md
@@ -77,7 +77,7 @@ python3 build.py --framework [glfw, macos] --strip_test
 
 ```bash
 # Build & Run the smoke test (exits 0 on pass, 1 on fail)
-python3 build.py --framework [glfw, macos] --run --test_case smoke --headless true
+python3 run.py --framework [glfw, macos] --test_case smoke --headless true
 echo "Exit code: $?"
 ```
 
@@ -137,7 +137,7 @@ static TestCaseRegistrar<MyFeatureTest> my_feature_test_registrar("my_feature");
 Then run it:
 
 ```bash
-python3 build.py --framework macos --run --test_case my_feature
+python3 run.py --framework macos --test_case my_feature
 ```
 
 ### Naming Rules

--- a/run.py
+++ b/run.py
@@ -1,0 +1,61 @@
+"""Build and launch the app: the development entry point for running sparkle.
+
+Runs the pipeline stages a launch consumes — build, cook, and for device
+frameworks package, whose product the run installs — then launches the app.
+Every other option passes through: build options to build.py, the rest to
+the app. With --skip_build no stage runs and the existing binary launches.
+"""
+
+import argparse
+import os
+import sys
+
+import build
+
+
+def launch_stages(framework):
+    """The stages a launch consumes: desktop runs read the cook output from the
+    build tree directly, device runs install the packaged product."""
+    stages = ["build"]
+    if build.cooker_framework(framework) is not None:
+        stages.append("cook")
+    if framework in build.DEVICE_FRAMEWORKS:
+        stages.append("package")
+    return stages
+
+
+def parse_run_args(args=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skip_build", action="store_true",
+                        help="Launch the existing binary without running any pipeline stage")
+    parsed_args, forwarded = parser.parse_known_args(args)
+
+    if any(arg == "--stage" or arg.startswith("--stage=") for arg in forwarded):
+        parser.error("--stage belongs to build.py; run.py always runs the stages a launch needs")
+
+    return parsed_args, forwarded
+
+
+def main():
+    os.chdir(build.SCRIPTPATH)
+
+    run_args, forwarded = parse_run_args()
+
+    args = build.parse_args(forwarded)
+    args["stages"] = [] if run_args.skip_build else launch_stages(args["framework"])
+
+    build.setup(args)
+    build.check_environment(args)
+
+    if args["stages"]:
+        build.build_project(args)
+
+    from build_system.builder_factory import create_builder
+
+    print("Running...")
+    exit_code = create_builder(args["framework"]).run(args)
+    sys.exit(exit_code or 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/build_system/test_build_stages.py
+++ b/tests/build_system/test_build_stages.py
@@ -18,27 +18,28 @@ SPEC.loader.exec_module(build_script)
 
 
 class ResolveStagesTest(unittest.TestCase):
-    def resolve(self, stage_args=None, skip_build=False, cook=False, archive=False,
-                framework="macos"):
-        return build_script.resolve_stages(stage_args, skip_build, cook, archive, framework)
+    def resolve(self, stage_args=None, framework="macos"):
+        return build_script.resolve_stages(stage_args, framework)
 
-    def test_default_is_build_and_cook_for_desktop(self):
+    def test_default_is_the_full_pipeline(self):
         with patch.object(build_script, "HOST_COOK_FRAMEWORK", "glfw"):
-            self.assertEqual(self.resolve(framework="macos"), ["build", "cook"])
-            self.assertEqual(self.resolve(framework="glfw"), ["build", "cook"])
-
-    def test_default_includes_package_for_device_frameworks(self):
-        with patch.object(build_script, "HOST_COOK_FRAMEWORK", "glfw"):
+            self.assertEqual(self.resolve(framework="macos"), ["build", "cook", "package"])
+            self.assertEqual(self.resolve(framework="glfw"), ["build", "cook", "package"])
             self.assertEqual(self.resolve(framework="android"), ["build", "cook", "package"])
-            self.assertEqual(self.resolve(framework="ios"), ["build", "cook", "package"])
 
-    def test_default_degrades_to_build_when_the_host_cannot_cook(self):
+    def test_default_drops_cook_when_the_host_cannot_cook(self):
         with patch.object(build_script, "HOST_COOK_FRAMEWORK", None):
             self.assertEqual(self.resolve(framework="android"), ["build", "package"])
-            self.assertEqual(self.resolve(framework="glfw"), ["build", "cook"])
+            # glfw cooks through its own binary regardless of the host
+            self.assertEqual(self.resolve(framework="glfw"), ["build", "cook", "package"])
 
     def test_all_selects_every_stage_in_canonical_order(self):
         self.assertEqual(self.resolve(["all"]), ["build", "cook", "package"])
+
+    def test_explicit_all_never_degrades(self):
+        with patch.object(build_script, "HOST_COOK_FRAMEWORK", None):
+            self.assertEqual(self.resolve(["all"], framework="android"),
+                             ["build", "cook", "package"])
 
     def test_explicit_stages_run_in_canonical_order(self):
         self.assertEqual(self.resolve(["package", "build"]), ["build", "package"])
@@ -46,21 +47,6 @@ class ResolveStagesTest(unittest.TestCase):
     def test_explicit_stage_never_implies_upstream(self):
         self.assertEqual(self.resolve(["package"]), ["package"])
         self.assertEqual(self.resolve(["cook"]), ["cook"])
-
-    def test_legacy_archive_means_build_and_package(self):
-        self.assertEqual(self.resolve(archive=True), ["build", "package"])
-
-    def test_legacy_cook_means_build_and_cook(self):
-        self.assertEqual(self.resolve(cook=True), ["build", "cook"])
-
-    def test_legacy_skip_build_cook_means_cook_only(self):
-        self.assertEqual(self.resolve(skip_build=True, cook=True), ["cook"])
-
-    def test_legacy_skip_build_alone_selects_nothing(self):
-        self.assertEqual(self.resolve(skip_build=True), [])
-
-    def test_explicit_stage_overrides_legacy_flags(self):
-        self.assertEqual(self.resolve(["cook"], skip_build=False, archive=True), ["cook"])
 
 
 class ValidateStagesTest(unittest.TestCase):

--- a/tests/build_system/test_build_stages.py
+++ b/tests/build_system/test_build_stages.py
@@ -126,6 +126,40 @@ class ValidateStagesTest(unittest.TestCase):
         build_script.validate_stages(["package"], "android")
 
 
+class SetupTest(unittest.TestCase):
+    def run_setup(self, stages, generate_only=False, configure_only=False, clangd=False):
+        args = {"stages": stages, "generate_only": generate_only,
+                "configure_only": configure_only, "clangd": clangd}
+        with patch.object(build_script, "run_git_submodule_update") as submodules, \
+                patch("resources.setup.setup_resources") as resources, \
+                patch("ide.setup.setup_ide") as ide:
+            build_script.setup(args)
+        return {"submodules": submodules.called, "resources": resources.called,
+                "ide": ide.called}
+
+    def test_build_stage_runs_every_setup_step(self):
+        self.assertEqual(self.run_setup(["build", "cook"]),
+                         {"submodules": True, "resources": True, "ide": True})
+
+    def test_cook_only_needs_resources_but_no_submodules(self):
+        self.assertEqual(self.run_setup(["cook"]),
+                         {"submodules": False, "resources": True, "ide": False})
+
+    def test_package_only_skips_all_setup(self):
+        self.assertEqual(self.run_setup(["package"]),
+                         {"submodules": False, "resources": False, "ide": False})
+
+    def test_run_without_stages_skips_all_setup(self):
+        self.assertEqual(self.run_setup([]),
+                         {"submodules": False, "resources": False, "ide": False})
+
+    def test_configure_modes_set_up_like_a_build(self):
+        for mode in ("generate_only", "configure_only", "clangd"):
+            with self.subTest(mode=mode):
+                self.assertEqual(self.run_setup([], **{mode: True}),
+                                 {"submodules": True, "resources": True, "ide": True})
+
+
 class PackageProjectTest(unittest.TestCase):
     class FakeBuilder:
         def __init__(self):

--- a/tests/build_system/test_run_entry.py
+++ b/tests/build_system/test_run_entry.py
@@ -1,0 +1,55 @@
+"""Tests for run.py stage selection and argument forwarding."""
+
+import contextlib
+import importlib.util
+import io
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+SPEC = importlib.util.spec_from_file_location(
+    "run_script", os.path.join(PROJECT_ROOT, "run.py"))
+run_script = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = run_script
+SPEC.loader.exec_module(run_script)
+
+build = run_script.build
+
+
+class LaunchStagesTest(unittest.TestCase):
+    def test_desktop_launch_builds_and_cooks(self):
+        with patch.object(build, "HOST_COOK_FRAMEWORK", "glfw"):
+            self.assertEqual(run_script.launch_stages("glfw"), ["build", "cook"])
+            self.assertEqual(run_script.launch_stages("macos"), ["build", "cook"])
+
+    def test_device_launch_packages_the_product_it_installs(self):
+        with patch.object(build, "HOST_COOK_FRAMEWORK", "glfw"):
+            self.assertEqual(run_script.launch_stages("android"),
+                             ["build", "cook", "package"])
+            self.assertEqual(run_script.launch_stages("ios"),
+                             ["build", "cook", "package"])
+
+    def test_launch_degrades_when_the_host_cannot_cook(self):
+        with patch.object(build, "HOST_COOK_FRAMEWORK", None):
+            self.assertEqual(run_script.launch_stages("android"), ["build", "package"])
+
+
+class ParseRunArgsTest(unittest.TestCase):
+    def test_skip_build_is_consumed_and_the_rest_forwarded(self):
+        run_args, forwarded = run_script.parse_run_args(
+            ["--skip_build", "--framework", "glfw", "--test_case", "smoke"])
+        self.assertTrue(run_args.skip_build)
+        self.assertEqual(forwarded, ["--framework", "glfw", "--test_case", "smoke"])
+
+    def test_stage_selection_is_rejected(self):
+        for stage_arg in (["--stage", "cook"], ["--stage=cook"]):
+            with self.assertRaises(SystemExit):
+                with contextlib.redirect_stderr(io.StringIO()):
+                    run_script.parse_run_args(stage_arg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/build_system/test_run_tests.py
+++ b/tests/build_system/test_run_tests.py
@@ -53,7 +53,7 @@ class RunTestsCommandTest(unittest.TestCase):
             ),
         ])
 
-    def test_hardware_run_uses_build_entry_point(self):
+    def test_hardware_run_uses_run_entry_point(self):
         command = run_tests.app_command(
             framework="macos",
             config="Release",
@@ -64,14 +64,13 @@ class RunTestsCommandTest(unittest.TestCase):
 
         self.assertEqual(command[:6], [
             sys.executable,
-            os.path.join(PROJECT_ROOT, "build.py"),
+            os.path.join(PROJECT_ROOT, "run.py"),
             "--framework",
             "macos",
             "--config",
             "Release",
         ])
         self.assertIn("--skip_build", command)
-        self.assertIn("--run", command)
         self.assertEqual(command[-4:], [
             "--test_case", "screenshot", "--pipeline", "forward"])
 

--- a/tests/camera/camera_nudge_test.py
+++ b/tests/camera/camera_nudge_test.py
@@ -38,12 +38,11 @@ def parse_args():
 
 
 def build_and_run(args, other_args):
-    build_py = os.path.join(PROJECT_ROOT, "build.py")
-    run_cmd = [sys.executable, build_py, "--framework", args.framework]
+    run_py = os.path.join(PROJECT_ROOT, "run.py")
+    run_cmd = [sys.executable, run_py, "--framework", args.framework]
     if args.skip_build:
         run_cmd.append("--skip_build")
-    run_cmd += ["--run",
-                "--test_case", "camera_nudge_return",
+    run_cmd += ["--test_case", "camera_nudge_return",
                 "--clear_screenshots", "true"] + other_args
     if args.headless:
         run_cmd += ["--headless", "true"]

--- a/tests/nrd/nrd_common.py
+++ b/tests/nrd/nrd_common.py
@@ -17,10 +17,10 @@ NUM_FRAMES = 16  # must match DenoiserSweepTest.cpp NumFrames
 
 
 def run_sweep(framework, extra, skip_build=False, headless=False):
-    cmd = [sys.executable, os.path.join(PROJECT_ROOT, "build.py"), "--framework", framework]
+    cmd = [sys.executable, os.path.join(PROJECT_ROOT, "run.py"), "--framework", framework]
     if skip_build:
         cmd.append("--skip_build")
-    cmd += ["--run", "--test_case", "denoiser_sweep", "--clear_screenshots", "true", "--pipeline", "gpu"]
+    cmd += ["--test_case", "denoiser_sweep", "--clear_screenshots", "true", "--pipeline", "gpu"]
     cmd += list(extra)
     if headless:
         cmd += ["--headless", "true"]
@@ -30,11 +30,11 @@ def run_sweep(framework, extra, skip_build=False, headless=False):
 
 
 def run_test_case(framework, test_case, extra, skip_build=False, headless=False):
-    cmd = [sys.executable, os.path.join(PROJECT_ROOT, "build.py"),
+    cmd = [sys.executable, os.path.join(PROJECT_ROOT, "run.py"),
            "--framework", framework]
     if skip_build:
         cmd.append("--skip_build")
-    cmd += ["--run", "--test_case", test_case] + list(extra)
+    cmd += ["--test_case", test_case] + list(extra)
     if headless:
         cmd += ["--headless", "true"]
     print("Running:", " ".join(cmd), flush=True)

--- a/tests/nrd/run_nrd_gates.py
+++ b/tests/nrd/run_nrd_gates.py
@@ -49,11 +49,11 @@ def main():
     args = parser.parse_args()
 
     py = sys.executable
-    build = [py, os.path.join(PROJECT_ROOT, "build.py"), "--framework", args.framework]
+    runner = [py, os.path.join(PROJECT_ROOT, "run.py"), "--framework", args.framework]
 
     # capability probe (also produces the converged reference for the firefly gate)
-    probe = build + (["--skip_build"] if args.skip_build else []) + [
-        "--run", "--test_case", "screenshot", "--pipeline", "gpu", "--headless", "true", "--max_spp", "512"]
+    probe = runner + (["--skip_build"] if args.skip_build else []) + [
+        "--test_case", "screenshot", "--pipeline", "gpu", "--headless", "true", "--max_spp", "512"]
     code, output = run(probe, capture=True)
     if "effective pipeline: Gpu" not in output:
         if args.allow_unsupported and "hardware ray tracing not supported" in output:

--- a/tests/scene/primitive_move_test.py
+++ b/tests/scene/primitive_move_test.py
@@ -37,12 +37,11 @@ def parse_args():
 
 
 def build_and_run(args, other_args):
-    build_py = os.path.join(PROJECT_ROOT, "build.py")
-    run_cmd = [sys.executable, build_py, "--framework", args.framework]
+    run_py = os.path.join(PROJECT_ROOT, "run.py")
+    run_cmd = [sys.executable, run_py, "--framework", args.framework]
     if args.skip_build:
         run_cmd.append("--skip_build")
-    run_cmd += ["--run",
-                "--test_case", "primitive_move",
+    run_cmd += ["--test_case", "primitive_move",
                 "--clear_screenshots", "true"] + other_args
     if args.headless:
         run_cmd += ["--headless", "true"]

--- a/tests/usd/usd_roundtrip_test.py
+++ b/tests/usd/usd_roundtrip_test.py
@@ -44,12 +44,11 @@ def parse_args():
 
 
 def build_and_run(args, other_args):
-    build_py = os.path.join(PROJECT_ROOT, "build.py")
-    run_cmd = [sys.executable, build_py, "--framework", args.framework]
+    run_py = os.path.join(PROJECT_ROOT, "run.py")
+    run_cmd = [sys.executable, run_py, "--framework", args.framework]
     if args.skip_build:
         run_cmd.append("--skip_build")
-    run_cmd += ["--run",
-                "--test_case", "usd_round_trip",
+    run_cmd += ["--test_case", "usd_round_trip",
                 "--clear_screenshots", "true",
                 "--pipeline", args.pipeline] + other_args
     if args.headless:


### PR DESCRIPTION
## Problem

Every `build.py` invocation ran the full setup — recursive submodule update, resource download, and IDE settings copy — even when nothing compiles. On CI this wastes significant time: the cook node paid a full recursive submodule clone for a stage that never touches thirdparty sources, and test nodes paid the clone *and* the resource download once per test case, despite running from a released package. Separately, `build.py` mixed pipeline and launcher duties behind overlapping flags (`--run`, `--cook`, `--archive`, `--skip_build`).

## Changes

**Commit 1 — stage-scoped setup.** `setup()` gates each step on the stage that consumes it:

- Submodule update and IDE settings copy: only when compiling or configuring (`build` stage, `--generate_only`, `--configure_only`, `--clangd`).
- Resource download: when compiling or when the `cook` stage runs — the build embeds `resources/packed` into the product and `assemble_cooked_image` copies it into the content image.
- Run-only and package-only invocations skip setup entirely.

**Commit 2 — split the launcher out of the pipeline.**

- `build.py` is now purely the pipeline (`build → cook → package`), selected with `--stage`. The default is every stage the host supports — a plain `build.py` produces a complete distributable, minus cook on hosts that cannot produce a cooker binary. Explicit selections (including `--stage all`) never degrade and fail fast instead.
- `run.py` is the launcher: it runs the stages a launch consumes — build, cook, and for device frameworks package, whose product the run installs — then launches the app, forwarding unrecognized options to it. `run.py --skip_build` launches the existing binary without running any stage.
- The `--run`, `--cook`, and `--archive` aliases are gone; `--skip_build` moved from build.py to run.py.
- Callers migrated: `dev/run_tests.py` and the standalone harnesses under `tests/` launch through `run.py`; the CI build-platform action selects `--stage build --stage package` explicitly; docs updated (Build/Run/Cooking/Test).

**Commit 3 — harden the CI job await.** A transient GitHub API error (e.g. a 503) during the wait-for-job poll aborted the awaiting job under `bash -e` instead of being retried, failing every release node of a run at once and, through their own awaits, the test nodes behind them. A failed poll now logs a retry line and keeps waiting; the existing 60-minute budget bounds a persistent outage. (Surfaced by the GitHub API incident during this PR's CI runs.)

No workflow-level changes; build, cook, release, and test nodes keep their exact stage behavior.

## Validation

- `tests/build_system` suite: 75 tests pass, including new `SetupTest` (setup gating), updated `ResolveStagesTest` (new defaults), and new `test_run_entry.py` (run.py stage selection, `--skip_build` forwarding, `--stage` rejection).
- Format gate passes with the CI-pinned formatter versions.
- Verified end-to-end that `run.py --skip_build` skips all setup and `run.py --stage` is rejected with a pointer to build.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExVpSPsjYWc8px6DYMNoRd