### PR TITLE
[CI] stop uploading duplicate compiler caches

### DIFF
--- a/.github/actions/build-platform/action.yml
+++ b/.github/actions/build-platform/action.yml
@@ -91,6 +91,24 @@ runs:
       shell: bash
       run: ccache -s || true
 
+    # the restore in setup-environment is save-less; upload a fresh entry only when this run
+    # compiled something (stats were zeroed above before the build), so a 100%-hit rebuild
+    # does not push a byte-identical duplicate into the 10GB actions-cache quota. an
+    # unparsable miss count leaves the output empty, which fails open into saving.
+    - name: Count new compiler cache entries
+      id: ccache-delta
+      if: always()
+      shell: bash
+      run: echo "misses=$(ccache --print-stats | awk '$1 == "cache_miss" { print $2 }')" >> "$GITHUB_OUTPUT"
+
+    # also saved after a failed build: the objects compiled before the failure warm the retry
+    - name: Save compiler cache
+      if: always() && steps.ccache-delta.outputs.misses != '0'
+      uses: actions/cache/save@v4
+      with:
+        path: ./.ccache
+        key: ${{ inputs.os }}-${{ inputs.framework }}-${{ inputs.build-type }}-ccache-${{ github.sha }}
+
     - name: Upload build product
       uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -44,9 +44,15 @@ runs:
           ${{ inputs.os }}-android-gradle-
 
     # compiled objects are cached with ccache across runs. the key always misses (github.sha)
-    # so the updated cache is saved after every run; restore-keys picks up the newest previous one.
-    - name: Cache compiler cache (All Platforms)
-      uses: actions/cache@v4
+    # so restore-keys picks up the newest previous cache. restore-only: build-platform uploads
+    # the updated cache, and only when the run compiled something new. saving here would
+    # re-upload the restored cache untouched from every job, and those duplicates crowd the
+    # repo's 10GB actions-cache quota until the entries other runs need get evicted (a cold
+    # windows rebuild costs ~20 minutes). jobs that never compile (cook, test, tidy) pass no
+    # build-type and skip the restore, so they stop keeping their dead cache entries alive.
+    - name: Restore compiler cache (All Platforms)
+      if: inputs.build-type != ''
+      uses: actions/cache/restore@v4
       with:
         path: ./.ccache
         key: ${{ inputs.os }}-${{ inputs.framework }}-${{ inputs.build-type }}-ccache-${{ github.sha }}


### PR DESCRIPTION
Every job that ran setup-environment saved a fresh sha-keyed ccache entry
on every run, even when nothing was compiled: build cells re-uploaded
100%-hit caches, and cook/test/tidy re-uploaded the restored cache
untouched under their own key families. The duplicates churned the repo's
10GB actions-cache quota until the entries the next run needed were
evicted, forcing periodic full cold rebuilds (~20 minutes on windows,
observed twice within one day).

Split the cache step: setup-environment now only restores (and skips even
that for callers without a build-type, which never compile), and
build-platform saves after the build, only when ccache counted at least
one miss, i.e. the cache actually gained new objects. Saves still happen
on PR runs and after failed builds, so retries stay warm.