### PR TITLE
Skip release stage for Debug builds in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,9 @@ on:
         default: '"Debug","Release"'
 
 # stages: build (every product in parallel, the heavy stage) -> cook (macos-release, on
-# the macos runners' real Metal GPU) -> release (every product: swap in the cooked
-# content image and re-sign) -> test (tests/coverage.csv decides which released products
+# the macos runners' real Metal GPU) -> release (every Release product: swap in the
+# cooked content image and re-sign; Debug builds are compile-coverage only and are
+# never released) -> test (tests/coverage.csv decides which released products
 # run the suite and with which cases). a cell waits only for the shared cook and its own product's
 # upstream cell, never other products': the stage -> cook edges are real needs edges,
 # while the edge to the product's own build (for release cells) or release (for test
@@ -129,6 +130,9 @@ jobs:
 
   release:
     needs: [plan, cook]
+    # debug builds get no release cell, so a Debug-only selection leaves this table
+    # empty, and GitHub rejects empty matrices
+    if: needs.plan.outputs.release != '[]'
     # apple signing needs a macos runner; injection elsewhere is zip surgery, ubuntu starts fastest
     runs-on: ${{ (matrix.framework == 'macos' || matrix.framework == 'ios') && 'macos-latest' || 'ubuntu-latest' }}
 

--- a/dev/ci_matrix.py
+++ b/dev/ci_matrix.py
@@ -98,10 +98,13 @@ def matrices(build_types):
     """The three include lists. Cell keys stay ordered os, framework, build_type:
     GitHub renders job display names from them (extras such as abi trail), and
     wait-for-job awaits cells by those names."""
-    release = [product_cell(product, build_type)
-               for product in PRODUCTS for build_type in build_types
-               if build_type in product.get("build_types", build_types)]
-    build = [cell for cell in release if cell not in STANDALONE_BUILDS]
+    cells = [product_cell(product, build_type)
+             for product in PRODUCTS for build_type in build_types
+             if build_type in product.get("build_types", build_types)]
+    # Debug products are compile-coverage only: nothing ships or tests them,
+    # so they get no release cell
+    release = [cell for cell in cells if cell["build_type"] == "Release"]
+    build = [cell for cell in cells if cell not in STANDALONE_BUILDS]
     test = [cell for cell in map(test_cell, covered_triplets())
             if cell["build_type"] in build_types]
     return {"build": build, "release": release, "test": test}

--- a/tests/build_system/test_ci_matrix.py
+++ b/tests/build_system/test_ci_matrix.py
@@ -17,13 +17,11 @@ SPEC.loader.exec_module(ci_matrix)
 
 class CiMatrixTest(unittest.TestCase):
 
-    def test_release_covers_every_product_and_config(self):
+    def test_release_covers_every_product_release_config_only(self):
+        # Debug products are compile-coverage only: they build but never release
         matrices = ci_matrix.matrices(["Debug", "Release"])
-        expected = [ci_matrix.product_cell(product, build_type)
-                    for product in ci_matrix.PRODUCTS
-                    for build_type in ("Debug", "Release")
-                    if build_type in product.get("build_types",
-                                                 ("Debug", "Release"))]
+        expected = [ci_matrix.product_cell(product, "Release")
+                    for product in ci_matrix.PRODUCTS]
         self.assertEqual(matrices["release"], expected)
 
     def test_restricted_products_never_leak_their_restriction(self):
@@ -34,6 +32,16 @@ class CiMatrixTest(unittest.TestCase):
                          ["Release"])
         for cell in android_x86:
             self.assertNotIn("build_types", cell)
+
+    def test_debug_products_still_build(self):
+        matrices = ci_matrix.matrices(["Debug", "Release"])
+        built = {(cell["os"], cell["framework"], cell.get("abi"),
+                  cell["build_type"]) for cell in matrices["build"]}
+        for product in ci_matrix.PRODUCTS:
+            if "Debug" not in product.get("build_types", ("Debug",)):
+                continue
+            self.assertIn((product["os"], product["framework"],
+                           product.get("abi"), "Debug"), built)
 
     def test_build_excludes_only_the_standalone_cook_build(self):
         matrices = ci_matrix.matrices(["Debug", "Release"])


### PR DESCRIPTION
Debug products exist only for compile coverage: nothing ships them and no test triplet consumes a Debug release artifact. This drops Debug cells from the release matrix in `dev/ci_matrix.py`, so CI stops running pointless release jobs for Debug builds while the build matrix keeps compiling them as before. The Release-only filter composes with the per-product `build_types` restriction from the android emulator work, so the release matrix is exactly one Release cell per product.

Supporting changes in `.github/workflows/build.yml`:
- Guard the release job with `if: needs.plan.outputs.release != '[]'` so a Debug-only build_type selection doesn't hit GitHub's empty-matrix rejection (same guard the test job already uses).
- Update the stage-diagram comment to note Debug builds are compile-coverage only.

Planner tests in `tests/build_system/test_ci_matrix.py` are updated to assert the new contract: the release matrix covers every product in Release config only, and Debug products still appear in the build matrix.

Verified by running `dev/ci_matrix.py` for all three build_type selections: Release-only output is unchanged, and Debug cells now appear only in the build matrix.