### PR TITLE
[Ui] hand imgui draw data to the render thread through the frame task queue

### DIFF
--- a/libraries/include/application/UiManager.h
+++ b/libraries/include/application/UiManager.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <array>
 #include <functional>
+#include <memory>
 
 class ImGuiIO;
 struct ImDrawData;
@@ -45,9 +45,7 @@ private:
 
     std::vector<CustomUiWindow> pending_windows_to_draw_;
 
-    std::array<ImDrawData *, 4> draw_data_per_frame_;
-
-    unsigned main_thread_context_index_ = 0;
-    unsigned render_thread_context_index_ = 0;
+    // render thread only; the main thread hands it over through the frame task queue
+    std::shared_ptr<ImDrawData> render_thread_draw_data_;
 };
 } // namespace sparkle

--- a/libraries/source/application/AppFramework.cpp
+++ b/libraries/source/application/AppFramework.cpp
@@ -543,9 +543,13 @@ bool AppFramework::MainLoop()
     {
         PROFILE_SCOPE("MainLoop render ui");
 
-        if (ui_manager_ && view_->CanRender())
+        if (ui_manager_)
         {
-            DrawUi();
+            if (view_->CanRender())
+            {
+                DrawUi();
+            }
+
             ui_manager_->Render();
         }
     }

--- a/libraries/source/application/UiManager.cpp
+++ b/libraries/source/application/UiManager.cpp
@@ -4,6 +4,7 @@
 #include "core/Exception.h"
 #include "core/FileManager.h"
 #include "core/ThreadManager.h"
+#include "core/task/TaskManager.h"
 
 #include <IconsFontAwesome7.h>
 #include <imgui.h>
@@ -164,8 +165,6 @@ UiManager::UiManager(NativeView *native_view) : native_view_(native_view)
 
     native_view_->InitUiSystem();
 
-    std::ranges::fill(draw_data_per_frame_, nullptr);
-
     // after this point, RHIUiHandler will call Init() in render thread
 }
 
@@ -181,11 +180,8 @@ void UiManager::Render()
 
     ASSERT(ThreadManager::IsInMainThread());
 
-    if (pending_windows_to_draw_.empty())
-    {
-        draw_data_per_frame_[main_thread_context_index_] = nullptr;
-    }
-    else
+    std::shared_ptr<ImDrawData> draw_data;
+    if (!pending_windows_to_draw_.empty())
     {
         native_view_->TickUiSystem();
 
@@ -199,15 +195,13 @@ void UiManager::Render()
         // render does not actually happen at this point.
         ImGui::Render();
 
-        FreeDrawData(draw_data_per_frame_[main_thread_context_index_]);
-
-        auto *draw_data_clone = CloneDrawData(ImGui::GetDrawData());
-        draw_data_per_frame_[main_thread_context_index_] = draw_data_clone;
+        draw_data = std::shared_ptr<ImDrawData>(CloneDrawData(ImGui::GetDrawData()), FreeDrawData);
 
         pending_windows_to_draw_.clear();
     }
 
-    main_thread_context_index_ = (main_thread_context_index_ + 1) % draw_data_per_frame_.size();
+    // hand over even when empty, so the render thread never redraws a stale clone
+    TaskManager::RunInRenderThread([this, draw_data]() { render_thread_draw_data_ = draw_data; });
 
     // after this point, RHIUiHandler will call BeginFrame() and Render() in render thread
 }
@@ -216,9 +210,7 @@ void UiManager::BeginRenderThread()
 {
     ASSERT(ThreadManager::IsInRenderThread());
 
-    ImGui::GetIO().UserData = draw_data_per_frame_[render_thread_context_index_];
-
-    render_thread_context_index_ = (render_thread_context_index_ + 1) % draw_data_per_frame_.size();
+    ImGui::GetIO().UserData = render_thread_draw_data_.get();
 }
 
 bool UiManager::HasDataToDraw()
@@ -245,7 +237,7 @@ void UiManager::Shutdown()
     // before this point, RHIUiHandler should have called Shutdown() in render thread
     native_view_->ShutdownUiSystem();
 
-    std::ranges::for_each(draw_data_per_frame_, FreeDrawData);
+    render_thread_draw_data_ = nullptr;
 
     ImGui::DestroyContext();
 


### PR DESCRIPTION
## Problem

The `surface_loss_recovery` case failed CI run #389 and passed #390 on the same commit. The flake was not a screenshot mismatch: the app SIGSEGV'd twice on the RenderThread inside `memcpy` ← `ImGui_ImplVulkan_RenderDrawData` ← `UiPass::Render`, before the after-recovery screenshot could be taken.

`UiManager` handed imgui draw data to the render thread through a 4-slot clone ring with two free-running indices, each advanced only when its thread sampled `CanRender()` true. The two samples happen 1-2 pipeline frames apart, so a surface loss flipping the flag between production and consumption desynced the indices for the rest of the run. The main thread could then free a clone while the render thread was still reading it.

Reproduced on an emulator with the stock release APK: guest CPU load plus repeated HOME/relaunch cycling crashed within 10 cycles, four times in a row, with the CI backtrace plus a variant dereferencing the freed clone directly in `VulkanUiHandler::Render`. Passing runs log `Vulkan surface lost while acquiring an image` (the render thread caught up and skipped symmetrically); crashing runs lack that line.

## Fix

The clone travels with its frame's render task batch: `UiManager::Render()` enqueues a `RunInRenderThread` handoff carrying the clone as a `shared_ptr`, and the render thread owns it from delivery until the next handoff replaces it. A frame that builds no UI hands over null, so stale data is never redrawn. The ring, both indices, the second `CanRender()` dependency, and an empty-frame slot leak all go away.

## Verification

* 150-cycle window-loss stress under guest CPU load: 0 crashes (previously 4 SIGSEGVs within ~10 cycles); the only process death was a system `LOW_MEMORY` kill per `dumpsys activity exit-info`, with no tombstone.
* `surface_loss_recovery` suite case passes on the emulator.
* Full `macos-macos-release` and `macos-glfw-release` suites pass, including cook gates.
* `check_format.py` and `check_tidy.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
