### PR TITLE
[CI] stop caching the emulator AVD and slim build_cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,16 +218,10 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # the AVD with its quickboot snapshot: the suite seeds it on a miss (cold boot
-      # + clean shutdown) and resumes from it in seconds on a hit. the system image
-      # stays out — sdkmanager refetches it faster than a gigabyte of shared cache
-      # quota is worth. bump the key suffix to discard a stale snapshot by hand
-      - name: Cache emulator AVD (android)
-        if: matrix.framework == 'android'
-        uses: actions/cache@v4
-        with:
-          path: ~/.android/avd
-          key: ${{ matrix.os }}-avd-${{ matrix.abi }}-api35-v1
+      # the AVD is deliberately NOT cached: the snapshot entry weighs ~4GB, and duplicated
+      # per branch it evicts every compiler cache in the repo's 10GB actions-cache quota
+      # (a cold windows rebuild costs ~20 minutes); the suite seeds a fresh AVD in ~5
+      # minutes instead (cold boot + clean shutdown)
 
       # the release package already carries the cooked content in its packed resources
       - name: Download app

--- a/build_system/prerequisites.py
+++ b/build_system/prerequisites.py
@@ -123,6 +123,8 @@ def install_cmake():
             f"Expected directory not found after extraction: {extracted_dir}")
 
     shutil.move(extracted_dir, cmake_dir)
+    # leftovers in tmp ride along in the CI-cached build_cache; drop them
+    shutil.rmtree(tmp_dir, ignore_errors=True)
     os.remove(download_path)
 
     if not os.path.exists(cmake_executable):
@@ -246,6 +248,9 @@ def install_vulkan_sdk(build_cache_dir):
     platform_name = platform_map[system]
 
     tmp_dir = os.path.join(build_cache_dir, "tmp")
+    # stale extraction leftovers — including ones restored from an older CI cache entry —
+    # would otherwise be re-saved into the CI-cached build_cache on every run
+    shutil.rmtree(tmp_dir, ignore_errors=True)
 
     prerequisites = load_prerequisites_versions()
     latest_version = prerequisites.get("VulkanSDK", "1.4.350.0")
@@ -352,6 +357,9 @@ def install_vulkan_sdk(build_cache_dir):
     install_with_retry(download_url, download_path, provision,
                        reset=lambda: shutil.rmtree(vulkan_sdk_path, ignore_errors=True))
 
+    # the extracted tree in tmp would otherwise ride along in the CI-cached build_cache,
+    # carrying the SDK twice (~doubling the ubuntu entry against the 10GB actions-cache quota)
+    shutil.rmtree(tmp_dir, ignore_errors=True)
     os.remove(download_path)
 
     if is_macos:


### PR DESCRIPTION
Compiler caches keep going cold on main: entries get evicted from the repo's 10GB actions-cache quota within the hour, forcing full cold rebuilds (~20 minutes on windows). Investigation of run logs (warm run 375 vs cold runs 385/392/396) traced the pressure to two quota hogs, not to the save-on-miss change in ab1b9d7:

- **The emulator AVD cache entry weighs ~3.95GB** (measured in run 392's android test job), 4x the "a gigabyte" estimate its comment assumed — and branch scoping duplicates it per active PR. This PR drops the cache step entirely: the suite already seeds a fresh AVD on a miss, which costs ~5 minutes per android test job.

- **The ubuntu build_cache entry doubled to ~1.1GB** because the Vulkan SDK install extracts the tarball into `build_cache/tmp`, copies the `x86_64` tree into place, and leaves the extracted tree behind to be cached alongside the installed copy (macos similarly leaves the extracted installer app). Now `tmp` is removed after provisioning — and also on entry, so entries restored from an old fat cache stop re-saving the leftovers (the key changes with `prerequisites.py`, so the next run saves a slim entry under the new key).

Expected effect: ~5GB of steady-state quota pressure gone, so main's ccache entries survive between runs and warm builds return.

Verified: `prerequisites.py` compiles, `build.yml` parses, and the `test_ci_matrix` suite passes.