### PR TITLE
[Build] host resources on google drive

### DIFF
--- a/resources/setup.py
+++ b/resources/setup.py
@@ -8,7 +8,7 @@ SCRIPTPATH = os.path.dirname(SCRIPT)
 def setup_resources():
     packed_dir = os.path.join(SCRIPTPATH, "packed")
     zip_path = os.path.join(SCRIPTPATH, "resources.zip")
-    url = "https://www.dropbox.com/scl/fo/q973wvw155dsrdf6wfkqt/ALzcfn5n44756u4NDKLJHl8?rlkey=l9kyje6xkf1tf6zsiv4bx98lj&st=wzo7vcll&dl=1"
+    url = "https://drive.usercontent.google.com/download?id=1QbM3lTuDaiozINaNqAkWDHkLF7UBQdRI&export=download&confirm=t"
 
     if os.path.exists(zip_path):
         print("Resources are up-to-date, skipping setup.")


### PR DESCRIPTION
Every CI job (and the latest main run) fails at resource setup: the dropbox folder link now serves an HTML page, so `build.py` dies with `BadZipFile: File is not a zip file`.

This lands the google-drive migration already staged in the working tree, with one correction: the plain `drive.google.com/uc?export=download` form returns a virus-scan interstitial (HTML) for files this size. The `drive.usercontent.google.com/download?...&confirm=t` endpoint serves the file directly — verified: 49 MB, valid zip, expected content layout (fonts/icons/models/skymap/...).

Unblocks #75 (and any other PR) — nothing builds until this merges.