### PR TITLE
[CI] chain job triplet names and warning-free annotations

### DIFF
--- a/.github/actions/build-platform/action.yml
+++ b/.github/actions/build-platform/action.yml
@@ -108,13 +108,13 @@ runs:
     # also saved after a failed build: the objects compiled before the failure warm the retry
     - name: Save compiler cache
       if: always() && steps.ccache-delta.outputs.misses != '0'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       with:
         path: ./.ccache
         key: ${{ inputs.os }}-${{ inputs.framework }}${{ inputs.abi != '' && format('-{0}', inputs.abi) || '' }}-${{ inputs.build-type }}-ccache-${{ github.sha }}
 
     - name: Upload build product
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build-${{ inputs.framework }}-${{ inputs.os }}-${{ inputs.build-type }}${{ inputs.abi != '' && format('-{0}', inputs.abi) || '' }}
         path: build_system/${{ inputs.framework }}/product

--- a/.github/actions/release-platform/action.yml
+++ b/.github/actions/release-platform/action.yml
@@ -39,13 +39,13 @@ runs:
   using: "composite"
   steps:
     - name: Download build product
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: build-${{ inputs.framework }}-${{ inputs.os }}-${{ inputs.build-type }}${{ inputs.abi != '' && format('-{0}', inputs.abi) || '' }}
         path: build_system/${{ inputs.framework }}/product
 
     - name: Download cooked content image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cooked-shared
         path: cooked
@@ -121,7 +121,7 @@ runs:
         app-path: ${{ steps.package.outputs.path }}
 
     - name: Upload release product
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: release-${{ inputs.framework }}-${{ inputs.os }}-${{ inputs.build-type }}${{ inputs.abi != '' && format('-{0}', inputs.abi) || '' }}
         path: build_system/${{ inputs.framework }}/product

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache Prerequisites (All Platforms)
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: |
           ./build_cache
@@ -37,7 +37,7 @@ runs:
     # the expensive (native) part of what they saved
     - name: Cache Gradle packages (Android)
       if: inputs.framework == 'android'
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: |
           ~/.gradle/caches
@@ -56,7 +56,7 @@ runs:
     # build-type and skip the restore, so they stop keeping their dead cache entries alive.
     - name: Restore compiler cache (All Platforms)
       if: inputs.build-type != ''
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: ./.ccache
         key: ${{ inputs.os }}-${{ inputs.framework }}${{ inputs.abi != '' && format('-{0}', inputs.abi) || '' }}-${{ inputs.build-type }}-ccache-${{ github.sha }}
@@ -85,6 +85,20 @@ runs:
           sudo apt-get install -y ccache
         fi
 
+    # the runner image ships third-party taps (e.g. aws/tap) that homebrew's tap-trust
+    # check warns about on every brew command; nothing here installs from them. the
+    # override silences the same warning during the untap itself. untap refuses taps
+    # with installed formulae (the image ships bicep from azure/bicep) — those are
+    # trusted taps that never warn, so they can stay
+    - name: Untap untrusted homebrew taps (macOS)
+      if: contains(inputs.os, 'macos')
+      shell: bash
+      run: |
+        export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
+        for tap in $(brew tap | grep -v '^homebrew/' || true); do
+          brew untap "$tap" || true
+        done
+
     - name: Setup GLFW Environment (All Platforms)
       if: inputs.framework == 'glfw'
       uses: aminya/setup-cpp@v1
@@ -109,14 +123,14 @@ runs:
 
     - name: Set up JDK 17 (Android)
       if: inputs.framework == 'android'
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: "17"
         distribution: "temurin"
 
     - name: Setup Android SDK (Android)
       if: inputs.framework == 'android'
-      uses: android-actions/setup-android@v3
+      uses: android-actions/setup-android@v4
 
     - name: Setup Xcode (macOS/iOS)
       if: inputs.framework == 'macos' || inputs.framework == 'ios'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       release: ${{ steps.plan.outputs.release }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Compute matrices
         id: plan
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build Platform
         uses: ./.github/actions/build-platform
@@ -69,7 +69,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build Platform
         uses: ./.github/actions/build-platform
@@ -84,7 +84,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Environment
         id: setup-environment
@@ -94,7 +94,7 @@ jobs:
           os: macos-latest
 
       - name: Download build product
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-macos-macos-latest-Release
           path: build_system/macos/product
@@ -123,7 +123,7 @@ jobs:
           test -f build_system/macos/output/cooked_image/cooked/manifest.json
 
       - name: Upload cooked content image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cooked-shared
           path: build_system/macos/output/cooked_image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -44,7 +44,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install formatters
         run: pip install clang-format==22.1.5 autopep8==2.3.2
       - name: Check formatting
@@ -58,7 +58,7 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Environment
         id: setup-environment
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # needs cannot target a single matrix cell, so the edge to this product's own build
       # is a job-name await. it only ever waits while few macos builds remain (cook, a
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # the suite drives the app through build.py, which needs the build prerequisites;
       # the android cell needs the SDK for adb and the emulator
@@ -121,7 +121,7 @@ jobs:
 
       # the release package already carries the cooked content in its packed resources
       - name: Download app
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-${{ inputs.framework }}-${{ inputs.os }}-${{ inputs.build_type }}${{ inputs.abi != '' && format('-{0}', inputs.abi) || '' }}
           path: build_system/${{ inputs.framework }}/product
@@ -200,7 +200,7 @@ jobs:
 
       - name: Upload Test Screenshot
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-screenshots-${{ inputs.framework }}-${{ inputs.os }}
           path: ${{ inputs.screenshots }}

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -35,7 +35,10 @@ on:
         default: ""
 
 jobs:
+  # explicit triplet names: the graph renders a called workflow's jobs by their own
+  # names, which would otherwise collapse every product to a bare "release"/"test"
   release:
+    name: release (${{ inputs.os }}, ${{ inputs.framework }}, ${{ inputs.build_type }}${{ inputs.abi != '' && format(', {0}', inputs.abi) || '' }})
     # apple signing needs a macos runner; injection elsewhere is zip surgery, ubuntu starts fastest
     runs-on: ${{ (inputs.framework == 'macos' || inputs.framework == 'ios') && 'macos-latest' || 'ubuntu-latest' }}
 
@@ -71,6 +74,7 @@ jobs:
           ios-appstore-private-key: ${{ secrets.APPSTORE_PRIVATE_KEY }}
 
   test:
+    name: test (${{ inputs.os }}, ${{ inputs.framework }}, ${{ inputs.build_type }}${{ inputs.abi != '' && format(', {0}', inputs.abi) || '' }})
     if: inputs.test
     needs: release
     runs-on: ${{ inputs.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
           generate_release_notes: true


### PR DESCRIPTION
Two CI-hygiene fixes for the graph and the annotations of recent runs (e.g. run 413).

## Chain job names

The pipeline graph renders a called workflow's jobs by their own job names, so since #75 every product's chain showed bare `release` / `test` nodes — only the surrounding group carried the triplet, misaligned with the build nodes. The chain jobs now carry explicit `name:`s built from their inputs, rendering the same `(os, framework, build_type[, abi])` display names as the build matrix. The one name-sensitive edge (wait-for-job's suffix match on `build (…)`) cannot match the new names.

## Warning annotations

Run 413 carried 27 warning annotations in two families, both fixed:

- **Node 20 deprecation** on every job: first-party actions bumped to their current majors — checkout v7, upload-artifact v7, download-artifact v8, cache v6, setup-java v5, setup-android v4, paths-filter v4, gh-release v3. All majors in between are runtime bumps; the two semantic changes in download-artifact (v5 by-id path layout, v8 hash enforcement) don't apply to by-name same-run downloads.
- **Homebrew tap-trust** (9×, every macos job): the runner image ships `aws/tap`, which homebrew now warns about on every brew command. Nothing installs from third-party taps, so setup-environment untaps them before the first brew step.

Touches disjoint lines from #72's release-test.yml changes, so both merge cleanly in either order.