### PR TITLE
[Doc] remove stale Android window-switching known issue

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -55,4 +55,3 @@
       load can mutate the replacement scene. Scene/component teardown needs
       generation-owned render commands or an explicit drain-before-destroy contract;
       load completion must then use the same generation boundary.
-* [ ] on Android, backgrounding and foregrounding the app races swapchain recreation against the render loop: `APP_CMD_INIT_WINDOW` schedules `RecreateSurface`/`RecreateSwapChain` while the render thread may sit in `VulkanContext::BeginFrame`, and the Adreno driver segfaults inside `vkWaitForFences`/`VulkanSwapChain::Recreate` roughly every other cycle (S25 Ultra, validation layer loaded). Window recreation needs to fence out the in-flight frame before the swapchain is replaced.


### PR DESCRIPTION
## Summary

Removes the Known Issues entry about Android window-switching crashes: the underlying bug is already fixed, and the entry is stale.

## Evidence

* The entry (3a5bee4, 2026-07-16 10:23) recorded crashes observed minutes earlier: on-device session logs (`output_2026_07_16_09_1*.log`) show five crash-relaunch cycles at 10:14-10:19, each process dying at `APP_CMD_INIT_WINDOW` on its first foreground transition.
* The root cause was the UiManager draw-data use-after-free fixed the next day by e004d33: at `INIT_WINDOW` the UI system re-initializes on the new window while the render thread could still consume a freed draw-data clone. The `vkWaitForFences` / `VulkanSwapChain::Recreate` stacks in the entry were heap-corruption misattribution, not a driver defect.
* Post-fix main survives ~200 targeted background/foreground cycles on the same S25 Ultra with zero crashes and zero stale-swapchain markers, including: the exact crash-era config and dwell timing (forward + validation, ~10s foreground / ~2.8s background), gpu pipeline at 2560x1440 spp 4 with validation, randomized rapid cycle storms, and cycles under CPU-load stress.
