### PR TITLE
[Package] name the content image in the package stage log

### DIFF
--- a/dev/package_cooked.py
+++ b/dev/package_cooked.py
@@ -158,7 +158,8 @@ def package_cooked(package, framework, image_dir, target):
                 zip_out.writestr(name, content)
     shutil.move(temp_path, package)
 
-    print(f"replaced content of {package} under {packed_root} with {len(placed)} image files")
+    print(f"replaced content of {package} under {packed_root} with the {target} content image"
+          f" ({len(placed)} files)")
     return len(placed)
 
 


### PR DESCRIPTION
The package stage logged its replacement as:

```
replaced content of build_system/glfw/product/linux-glfw-Release.zip under build/packed/ with 38 image files
```

"image files" means files from the target's content image, but next to a cook stage that spends most of its time on textures it reads as picture files, and the count covers the whole image: passed-through packed assets, projected artifacts, and the two `cooked/` manifests alike. The line now names the target and calls them files:

```
replaced content of build_system/glfw/product/linux-glfw-Release.zip under build/packed/ with the linux-glfw content image (38 files)
```

Log wording only, no behavior change. Nothing in `tests/` or `docs/` matched the old string.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kd4jTmjZSbKe1pxoUEXK8P)_