### PR TITLE
Let each module claim the input it implements

### DIFF
--- a/docs/Input.md
+++ b/docs/Input.md
@@ -14,22 +14,35 @@ tests (injection)  ┘          ├─ map to scene events        ──►     
 ```
 
 * **Raw events** ([InputEvents.h](../libraries/include/application/InputEvents.h)): `PointerEvent` (mouse and touch unified: device, action, pointer id, button, modifiers, position), `ScrollEvent`, `KeyEvent`, `CharEvent`.
-* **Scene events** (subscribe via `Event<Args...>` / RAII `EventSubscription`, [core/Event.h](../libraries/include/core/Event.h)): `OnScenePointer` (gated raw pointers, incl. synthesized `Cancel` when the ui takes over a sequence), `OnSceneDrag` (delta while the primary pointer is pressed), `OnSceneZoom` (wheel and pinch unified), `OnSceneTap(finger_count)`, `OnSceneDoubleTap`, `OnSceneKey`. They are broadcast: any number of modules may observe the same event.
-* **Key bindings** (`InputManager::BindKey`): a `KeyBinding` is a key, a `KeyAction`, and the modifiers that must be held (extra modifiers do not block it). Unlike scene events, a binding is exclusive — the slot has exactly one owner and claiming a taken slot asserts, so two modules cannot silently fight over a shortcut. The slot is freed when the returned subscription dies.
+* **Scene events** (subscribe via `Event<Args...>` / RAII `EventSubscription`, [core/Event.h](../libraries/include/core/Event.h)): `OnScenePointer` (gated raw pointers, incl. synthesized `Cancel` when the ui takes over a sequence), `OnSceneDrag` (delta while the primary pointer is pressed), `OnSceneZoom` (wheel and pinch unified), `OnSceneTap(finger_count)`, `OnSceneDoubleTap`. They are broadcast: any number of modules may observe the same event.
+* **Key bindings** (`InputManager::BindKey`): a `KeyBinding` is a key, a `KeyAction`, and the modifiers that must be held (extra modifiers do not block it). A binding is claimed in an `InputLayer` and freed when the returned subscription dies.
 
 Events are queued by `Push` (main thread only) and delivered once per frame from the main loop, in push order — input handling is deterministic with respect to frames.
+
+## Key arbitration
+
+A key often means different things to different modules — `Escape` dismisses the config panel, and it also exits the app. `InputLayer` resolves that without either module knowing about the other:
+
+* Layers answer a key in declaration order (`Ui`, then `Scene`), and a handler returns `true` to consume the key, which stops lower layers from seeing it.
+* An owner that is currently irrelevant — a panel that is closed — returns `false`, and the key falls through to the layer below as if the binding did not exist.
+* Within one layer a key has exactly one owner; claiming a key a second time in the same layer asserts. Two owners in one layer have no defined order, whereas two owners in different layers do.
+
+Everything a key can reach is therefore visible from its bindings, and a new consumer of an already-bound key is added by picking a layer rather than by editing the module that already owns it.
+
+While imgui wants the keyboard (`IsHandlingKeyboardEvent`, e.g. a focused text field) no binding runs in any layer — imgui itself is the owner of the keystroke.
 
 ## Ownership
 
 Every input is implemented and claimed by the module that owns the state it changes, not by a central dispatcher. `InputManager::Instance()` gives a module access without any wiring from the app layer; it is null in cook mode, so a module must tolerate its absence.
 
-| input | owner |
-| --- | --- |
-| pointer down/up, drag, zoom, `Up`/`Down` (aperture), `P` (print posture) | `CameraComponent::BindSceneInput`, resolving the scene's current main camera |
-| `Space` hold (manual accumulation) | `RenderConfig::BindInput` |
-| secondary or ctrl + primary click (debug point) | `RenderFramework` |
-| `NumpadAdd` / `Shift`+`Equal` / `Minus` (debug spheres) | `SceneManager::BindDebugInput` |
-| `Escape` (exit), double tap (config panel), 4-finger tap (frame capture) | `AppFramework` |
+| input | layer | owner |
+| --- | --- | --- |
+| pointer down/up, drag, zoom, `Up`/`Down` (aperture), `P` (print posture) | `Scene` | `CameraComponent::BindSceneInput`, resolving the scene's current main camera |
+| `Space` hold (manual accumulation) | `Scene` | `RenderConfig::BindInput` |
+| secondary or ctrl + primary click (debug point) | — | `RenderFramework` |
+| `NumpadAdd` / `Shift`+`Equal` / `Minus` (debug spheres) | `Scene` | `SceneManager::BindDebugInput` |
+| `Escape` (dismiss the config panel) | `Ui` | `AppFramework` |
+| `Escape` (exit), double tap (config panel), 4-finger tap (frame capture) | `Scene` | `AppFramework` |
 
 Scene-owned bindings live for the lifetime of the `Scene` and resolve the state they act on at dispatch time, so loading another scene never rebinds them.
 

--- a/docs/Input.md
+++ b/docs/Input.md
@@ -13,11 +13,25 @@ tests (injection)  ┘          ├─ map to scene events        ──►     
                               └─ dispatch key bindings      ──►
 ```
 
-* **Raw events** ([InputEvents.h](../libraries/include/application/InputEvents.h)): `PointerEvent` (mouse and touch unified: device, action, pointer id, button, modifiers, position), `ScrollEvent`, `KeyEvent`, `CharEvent`.
-* **Scene events** (subscribe via `Event<Args...>` / RAII `EventSubscription`, [core/Event.h](../libraries/include/core/Event.h)): `OnScenePointer` (gated raw pointers, incl. synthesized `Cancel` when the ui takes over a sequence), `OnSceneDrag` (delta while the primary pointer is pressed), `OnSceneZoom` (wheel and pinch unified), `OnSceneTap(finger_count)`, `OnSceneDoubleTap`. They are broadcast: any number of modules may observe the same event.
+* **Raw events** ([InputEvents.h](../libraries/include/application/InputEvents.h)): `PointerEvent` (mouse and touch unified: device, action, pointer id, button, modifiers, position), `ScrollEvent`, `KeyEvent`, `CharEvent`. They cross only the platform boundary — no module outside `InputManager` handles them.
+* **Scene events** (subscribe via `Event<Args...>` / RAII `EventSubscription`, [core/Event.h](../libraries/include/core/Event.h)) are recognized gestures, not pointers. They are broadcast: any number of modules may observe one.
 * **Key bindings** (`InputManager::BindKey`): a `KeyBinding` is a key, a `KeyAction`, and the modifiers that must be held (extra modifiers do not block it). A binding is claimed in an `InputLayer` and freed when the returned subscription dies.
 
 Events are queued by `Push` (main thread only) and delivered once per frame from the main loop, in push order — input handling is deterministic with respect to frames.
+
+## Scene gestures
+
+Recognition — which button, which modifier, how many fingers, how long — happens once inside `InputManager`, so no subscriber re-derives it and mouse and touch reach a subscriber through the same event:
+
+| scene event | mouse | touch |
+| --- | --- | --- |
+| `OnSceneDragBegin` / `OnSceneDrag(delta)` / `OnSceneDragEnd` | primary button pressed and moving | one finger |
+| `OnSceneZoom(amount)` | wheel | pinch |
+| `OnSceneSecondaryClick(position)` | secondary button, or control + primary | — |
+| `OnSceneTap(finger_count)` | — | quick tap, no slop |
+| `OnSceneDoubleTap(finger_count)` | double click | double tap |
+
+A drag always ends: `OnSceneDragEnd` fires on release and also when the ui takes the sequence over mid-drag, so an owner that started acting on `Begin` can rely on `End` to stop.
 
 ## Key arbitration
 
@@ -37,14 +51,16 @@ Every input is implemented and claimed by the module that owns the state it chan
 
 | input | layer | owner |
 | --- | --- | --- |
-| pointer down/up, drag, zoom, `Up`/`Down` (aperture), `P` (print posture) | `Scene` | `CameraComponent::BindSceneInput`, resolving the scene's current main camera |
+| drag, zoom, `Up`/`Down` (aperture), `P` (print posture) | `Scene` | `CameraComponent::BindSceneInput`, resolving the scene's current main camera |
 | `Space` hold (manual accumulation) | `Scene` | `RenderConfig::BindInput` |
-| secondary or ctrl + primary click (debug point) | — | `RenderFramework` |
+| secondary click (debug point) | — | `RenderFramework` |
 | `NumpadAdd` / `Shift`+`Equal` / `Minus` (debug spheres) | `Scene` | `SceneManager::BindDebugInput` |
 | `Escape` (dismiss the config panel) | `Ui` | `AppFramework` |
 | `Escape` (exit), double tap (config panel), 4-finger tap (frame capture) | `Scene` | `AppFramework` |
 
 Scene-owned bindings live for the lifetime of the `Scene` and resolve the state they act on at dispatch time, so loading another scene never rebinds them.
+
+Because a gesture is recognized once, the handlers a module writes are the whole of what it needs: `CameraComponent`'s `OnDragBegin` / `OnDrag` / `OnDragEnd` / `OnZoom` are protected, driven only by the bindings the camera itself claims.
 
 ## Coordinate space
 
@@ -62,7 +78,7 @@ Gesture recognition is shared engine code, identical on ios and android (platfor
 
 | gesture | scene event |
 | --- | --- |
-| 1-finger drag | `OnScenePointer` Down/Up + `OnSceneDrag` |
+| 1-finger drag | `OnSceneDragBegin` / `OnSceneDrag` / `OnSceneDragEnd` |
 | pinch (2 fingers) | `OnSceneZoom` from the pinch length delta; suppresses drag; lifting back to one finger resumes the drag |
 | quick tap, no slop | `OnSceneTap(finger_count)`; 1-finger taps also drive double-tap detection (4-finger tap triggers a frame capture) |
 | touch → ui | single finger emulates an imgui mouse: short = click, longer drag = wheel scroll, hover reset after each sequence |

--- a/docs/Input.md
+++ b/docs/Input.md
@@ -5,17 +5,33 @@ All user input flows through a single pipeline owned by `InputManager` ([librari
 ```text
 platform layer                InputManager                       subscribers
 ──────────────                ─────────────────────────────      ─────────────────
-glfw callbacks     ┐          Push(InputEvent)  → queue
-macos NSEvents     ├─ raw ──► DispatchPendingEvents()            AppFramework
-ios raw touches    │          ├─ feed imgui (io.Add*Event)       (camera routing,
-android motions    │          ├─ ui capture gate                  app shortcuts,
-tests (injection)  ┘          └─ map to scene events        ──►   panel toggle, …)
+glfw callbacks     ┐          Push(InputEvent)  → queue           camera, renderer,
+macos NSEvents     ├─ raw ──► DispatchPendingEvents()             scene, app, …
+ios raw touches    │          ├─ feed imgui (io.Add*Event)        (each module claims
+android motions    │          ├─ ui capture gate                   the inputs it
+tests (injection)  ┘          ├─ map to scene events        ──►     implements)
+                              └─ dispatch key bindings      ──►
 ```
 
 * **Raw events** ([InputEvents.h](../libraries/include/application/InputEvents.h)): `PointerEvent` (mouse and touch unified: device, action, pointer id, button, modifiers, position), `ScrollEvent`, `KeyEvent`, `CharEvent`.
-* **Scene events** (subscribe via `Event<Args...>` / RAII `EventSubscription`, [core/Event.h](../libraries/include/core/Event.h)): `OnScenePointer` (gated raw pointers, incl. synthesized `Cancel` when the ui takes over a sequence), `OnSceneDrag` (delta while the primary pointer is pressed), `OnSceneZoom` (wheel and pinch unified), `OnSceneTap(finger_count)`, `OnSceneDoubleTap`, `OnSceneKey`.
+* **Scene events** (subscribe via `Event<Args...>` / RAII `EventSubscription`, [core/Event.h](../libraries/include/core/Event.h)): `OnScenePointer` (gated raw pointers, incl. synthesized `Cancel` when the ui takes over a sequence), `OnSceneDrag` (delta while the primary pointer is pressed), `OnSceneZoom` (wheel and pinch unified), `OnSceneTap(finger_count)`, `OnSceneDoubleTap`, `OnSceneKey`. They are broadcast: any number of modules may observe the same event.
+* **Key bindings** (`InputManager::BindKey`): a `KeyBinding` is a key, a `KeyAction`, and the modifiers that must be held (extra modifiers do not block it). Unlike scene events, a binding is exclusive — the slot has exactly one owner and claiming a taken slot asserts, so two modules cannot silently fight over a shortcut. The slot is freed when the returned subscription dies.
 
 Events are queued by `Push` (main thread only) and delivered once per frame from the main loop, in push order — input handling is deterministic with respect to frames.
+
+## Ownership
+
+Every input is implemented and claimed by the module that owns the state it changes, not by a central dispatcher. `InputManager::Instance()` gives a module access without any wiring from the app layer; it is null in cook mode, so a module must tolerate its absence.
+
+| input | owner |
+| --- | --- |
+| pointer down/up, drag, zoom, `Up`/`Down` (aperture), `P` (print posture) | `CameraComponent::BindSceneInput`, resolving the scene's current main camera |
+| `Space` hold (manual accumulation) | `RenderConfig::BindInput` |
+| secondary or ctrl + primary click (debug point) | `RenderFramework` |
+| `NumpadAdd` / `Shift`+`Equal` / `Minus` (debug spheres) | `SceneManager::BindDebugInput` |
+| `Escape` (exit), double tap (config panel), 4-finger tap (frame capture) | `AppFramework` |
+
+Scene-owned bindings live for the lifetime of the `Scene` and resolve the state they act on at dispatch time, so loading another scene never rebinds them.
 
 ## Coordinate space
 

--- a/libraries/include/application/AppFramework.h
+++ b/libraries/include/application/AppFramework.h
@@ -127,21 +127,10 @@ public:
 #endif
 
 private:
+    // claims only the inputs the app itself owns. every other module claims its own.
     void SetupInputHandlers();
 
-    // the scene key bindings and the actions they dispatch to
-    void HandleSceneKey(const KeyEvent &event);
-    void HoldAccumulation();
-    void ReleaseAccumulation();
-    void WidenAperture() const;
-    void NarrowAperture() const;
-    void PrintCameraPosture() const;
-    void AddDebugSphere();
-    void RemoveDebugSphere();
-
     void AdvanceFrame(float main_thread_time);
-
-    void DebugNextFrame();
 
     void MeasurePerformance(float delta_time);
 

--- a/libraries/include/application/InputEvents.h
+++ b/libraries/include/application/InputEvents.h
@@ -73,6 +73,19 @@ struct CharEvent
     uint32_t codepoint = 0;
 };
 
+// declaration order is dispatch order: a layer only sees a key that no layer above it consumed.
+// several layers may claim the same key — that is how a shortcut can mean one thing in the ui
+// and another in the scene.
+enum class InputLayer : uint8_t
+{
+    // ui panels and widgets. they answer first, so dismissing a panel wins over what the same
+    // key does in the scene.
+    Ui,
+    // camera, scene content, renderer, and app-wide shortcuts
+    Scene,
+    Count
+};
+
 // a keyboard shortcut a module claims from InputManager. it fires when the key reaches the
 // given action while every required modifier is held; extra modifiers do not block it.
 struct KeyBinding

--- a/libraries/include/application/InputEvents.h
+++ b/libraries/include/application/InputEvents.h
@@ -73,5 +73,16 @@ struct CharEvent
     uint32_t codepoint = 0;
 };
 
+// a keyboard shortcut a module claims from InputManager. it fires when the key reaches the
+// given action while every required modifier is held; extra modifiers do not block it.
+struct KeyBinding
+{
+    Key key = Key::Unknown;
+    KeyAction action = KeyAction::Release;
+    uint32_t modifiers = 0;
+
+    bool operator==(const KeyBinding &other) const = default;
+};
+
 using InputEvent = std::variant<PointerEvent, ScrollEvent, KeyEvent, CharEvent>;
 } // namespace sparkle

--- a/libraries/include/application/InputManager.h
+++ b/libraries/include/application/InputManager.h
@@ -4,6 +4,9 @@
 #include "core/Event.h"
 #include "core/Timer.h"
 
+#include <functional>
+#include <memory>
+#include <utility>
 #include <vector>
 
 namespace sparkle
@@ -14,6 +17,10 @@ class UiManager;
 // receives raw input events from platform code (or tests, for injection), feeds the ui
 // system, and maps them to scene events that any module can subscribe to.
 // scene events are suppressed while the ui captures the pointer or keyboard.
+//
+// there are two tiers of interest:
+//   * scene events (On*) are broadcast, for any module that wants to observe an input.
+//   * key bindings (BindKey) are exclusive, because a shortcut belongs to exactly one owner.
 class InputManager
 {
 public:
@@ -58,6 +65,18 @@ public:
 
     InputManager(const AppConfig &app_config, UiManager *ui_manager);
 
+    ~InputManager();
+
+    InputManager(const InputManager &) = delete;
+    InputManager &operator=(const InputManager &) = delete;
+
+    // the app owns the only instance. cook mode runs without one, so modules that bind their
+    // own inputs must tolerate a null instance.
+    static InputManager *Instance()
+    {
+        return instance_;
+    }
+
     // main thread only
     void Push(const InputEvent &event);
 
@@ -65,11 +84,6 @@ public:
     void DispatchPendingEvents();
 
     void Reset();
-
-    [[nodiscard]] Vector2 GetPointerPosition() const
-    {
-        return pointer_position_;
-    }
 
     auto &OnScenePointer()
     {
@@ -105,6 +119,12 @@ public:
         return scene_key_event_.OnTrigger();
     }
 
+    // claims a keyboard shortcut for one owner. the slot is freed when the returned subscription
+    // dies, and claiming a slot that is already taken asserts.
+    // main thread only.
+    [[nodiscard]] std::unique_ptr<EventSubscription> BindKey(const KeyBinding &binding,
+                                                             std::function<void()> &&handler);
+
 private:
     void Process(const PointerEvent &event);
     void Process(const ScrollEvent &event);
@@ -137,6 +157,10 @@ private:
     Event<uint8_t> scene_double_tap_event_;
     Event<uint8_t> scene_tap_event_;
     Event<const KeyEvent &> scene_key_event_;
+
+    // few enough that a linear scan beats hashing. every slot is exclusive, so a shortcut has
+    // at most one owner at a time.
+    std::vector<std::pair<KeyBinding, Event<>>> key_bindings_;
 
     UiCaptureGate gate_;
 
@@ -177,5 +201,7 @@ private:
     };
 
     UiTouchEmulation ui_touch_;
+
+    static InputManager *instance_;
 };
 } // namespace sparkle

--- a/libraries/include/application/InputManager.h
+++ b/libraries/include/application/InputManager.h
@@ -6,7 +6,6 @@
 
 #include <functional>
 #include <memory>
-#include <utility>
 #include <vector>
 
 namespace sparkle
@@ -20,10 +19,16 @@ class UiManager;
 //
 // there are two tiers of interest:
 //   * scene events (On*) are broadcast, for any module that wants to observe an input.
-//   * key bindings (BindKey) are exclusive, because a shortcut belongs to exactly one owner.
+//   * key bindings (BindKey) are arbitrated: one owner per key per InputLayer, and the layers
+//     answer in order until one consumes the key.
 class InputManager
 {
 public:
+    // returns true when the binding consumed the key, which stops lower layers from seeing it.
+    // an owner that is currently irrelevant (a panel that is closed) returns false and lets the
+    // key fall through.
+    using KeyHandler = std::function<bool()>;
+
     // a pointer sequence that starts on the ui stays on the ui until release, even if
     // the pointer leaves it in between. touch consults ShouldConsume only at sequence
     // boundaries (first finger down, last finger up) and reads IsSequenceActive in
@@ -114,18 +119,41 @@ public:
         return scene_tap_event_.OnTrigger();
     }
 
-    auto &OnSceneKey()
-    {
-        return scene_key_event_.OnTrigger();
-    }
-
-    // claims a keyboard shortcut for one owner. the slot is freed when the returned subscription
-    // dies, and claiming a slot that is already taken asserts.
+    // claims a keyboard shortcut in one layer. the slot is freed when the returned subscription
+    // dies, and claiming a slot another owner already holds in the same layer asserts — two
+    // owners in one layer have no defined order, unlike two owners in different layers.
     // main thread only.
-    [[nodiscard]] std::unique_ptr<EventSubscription> BindKey(const KeyBinding &binding,
-                                                             std::function<void()> &&handler);
+    [[nodiscard]] std::unique_ptr<EventSubscription> BindKey(InputLayer layer, const KeyBinding &binding,
+                                                             KeyHandler &&handler);
 
 private:
+    // the key slots of every layer. unlike Event, a slot holds a single handler that reports
+    // consumption, which is what lets the layers arbitrate. it reuses EventSubscription so a
+    // binding's lifetime works exactly like an event subscription's.
+    class KeyBindings : public EventListenerBase
+    {
+    public:
+        [[nodiscard]] uint32_t Add(InputLayer layer, const KeyBinding &binding, KeyHandler &&handler);
+
+        // runs the layer's binding for this key, if any. returns true when it consumed the key.
+        bool Dispatch(InputLayer layer, const KeyEvent &event);
+
+    protected:
+        bool RemoveCallback(uint32_t id) override;
+
+    private:
+        struct Slot
+        {
+            InputLayer layer;
+            KeyBinding binding;
+            KeyHandler handler;
+            uint32_t id;
+        };
+
+        // few enough that a linear scan beats hashing
+        std::vector<Slot> slots_;
+    };
+
     void Process(const PointerEvent &event);
     void Process(const ScrollEvent &event);
     void Process(const KeyEvent &event);
@@ -156,11 +184,8 @@ private:
     Event<float> scene_zoom_event_;
     Event<uint8_t> scene_double_tap_event_;
     Event<uint8_t> scene_tap_event_;
-    Event<const KeyEvent &> scene_key_event_;
 
-    // few enough that a linear scan beats hashing. every slot is exclusive, so a shortcut has
-    // at most one owner at a time.
-    std::vector<std::pair<KeyBinding, Event<>>> key_bindings_;
+    std::shared_ptr<KeyBindings> key_bindings_ = std::make_shared<KeyBindings>();
 
     UiCaptureGate gate_;
 

--- a/libraries/include/application/InputManager.h
+++ b/libraries/include/application/InputManager.h
@@ -17,6 +17,10 @@ class UiManager;
 // system, and maps them to scene events that any module can subscribe to.
 // scene events are suppressed while the ui captures the pointer or keyboard.
 //
+// scene events are gestures, not pointers: recognition (which button, which modifier, how many
+// fingers, how long) happens here once, so no subscriber re-derives it and mouse and touch reach
+// a subscriber through the same event.
+//
 // there are two tiers of interest:
 //   * scene events (On*) are broadcast, for any module that wants to observe an input.
 //   * key bindings (BindKey) are arbitrated: one owner per key per InputLayer, and the layers
@@ -90,21 +94,36 @@ public:
 
     void Reset();
 
-    auto &OnScenePointer()
+    // a drag is the primary pointer pressed and moving: mouse button or one finger. it always
+    // ends, on release or on the ui taking the sequence over, so an owner that started acting on
+    // Begin can rely on End to stop.
+    auto &OnSceneDragBegin()
     {
-        return scene_pointer_event_.OnTrigger();
+        return scene_drag_begin_event_.OnTrigger();
     }
 
-    // drag delta in ui space while the primary pointer is pressed
+    // drag delta in ui space
     auto &OnSceneDrag()
     {
         return scene_drag_event_.OnTrigger();
     }
 
-    // positive amount zooms out, matching OrbitCameraComponent::OnScroll
+    auto &OnSceneDragEnd()
+    {
+        return scene_drag_end_event_.OnTrigger();
+    }
+
+    // positive amount zooms out, matching OrbitCameraComponent::OnZoom
     auto &OnSceneZoom()
     {
         return scene_zoom_event_.OnTrigger();
+    }
+
+    // payload is the click position in ui space. the secondary button and control + primary both
+    // produce it; touch has no secondary gesture yet.
+    auto &OnSceneSecondaryClick()
+    {
+        return scene_secondary_click_event_.OnTrigger();
     }
 
     // payload is the finger count of the tap (1 for mouse double click)
@@ -172,15 +191,17 @@ private:
 
     void CancelScenePointer();
     void HandleClick();
-    void BeginTouchDrag(uint8_t id, const Vector2 &position);
+    void BeginTouchDrag();
 
     const AppConfig &app_config_;
     UiManager *ui_manager_ = nullptr;
 
     std::vector<InputEvent> pending_events_;
 
-    Event<const PointerEvent &> scene_pointer_event_;
+    Event<> scene_drag_begin_event_;
     Event<Vector2> scene_drag_event_;
+    Event<> scene_drag_end_event_;
+    Event<Vector2> scene_secondary_click_event_;
     Event<float> scene_zoom_event_;
     Event<uint8_t> scene_double_tap_event_;
     Event<uint8_t> scene_tap_event_;

--- a/libraries/include/application/RenderFramework.h
+++ b/libraries/include/application/RenderFramework.h
@@ -2,6 +2,7 @@
 
 #include "core/Event.h"
 #include "core/Timer.h"
+#include "core/math/Types.h"
 #include "renderer/RenderConfig.h"
 
 #include <atomic>
@@ -62,9 +63,6 @@ public:
     void PushRenderTasks();
 
     // called by main thread, run on render thread
-    void SetDebugPoint(float x, float y);
-
-    // called by main thread, run on render thread
     void OnFrameBufferResize(int width, int height);
 
     // called by main thread, run on render thread
@@ -97,6 +95,13 @@ public:
     [[nodiscard]] bool IsSceneFullyLoaded() const;
 
 private:
+    // called by main thread. converts the ui-space position into render-target space and hands
+    // it to the render thread.
+    void RequestDebugPoint(const Vector2 &ui_position);
+
+    // render thread only
+    void SetDebugPoint(float x, float y);
+
     void ProcessScreenshotRequest();
     void RenderThreadMain();
 
@@ -142,6 +147,8 @@ private:
     float last_second_gpu_time_ = 0.f;
 
     Event<> renderer_created_event_;
+
+    std::unique_ptr<EventSubscription> pointer_subscription_;
 
     TimerCaller frame_rate_monitor_;
 

--- a/libraries/include/application/RenderFramework.h
+++ b/libraries/include/application/RenderFramework.h
@@ -148,7 +148,7 @@ private:
 
     Event<> renderer_created_event_;
 
-    std::unique_ptr<EventSubscription> pointer_subscription_;
+    std::unique_ptr<EventSubscription> secondary_click_subscription_;
 
     TimerCaller frame_rate_monitor_;
 

--- a/libraries/include/core/Event.h
+++ b/libraries/include/core/Event.h
@@ -12,6 +12,15 @@ namespace sparkle
 {
 class EventListenerBase;
 
+enum class EventPolicy : uint8_t
+{
+    // any number of listeners may observe the event
+    Broadcast,
+    // at most one listener at a time. use it for slots that represent ownership rather than
+    // observation, so that two owners cannot silently fight over the same signal.
+    Exclusive,
+};
+
 class EventSubscription
 {
 public:
@@ -97,9 +106,16 @@ template <typename... Args> class Event;
 template <typename... Args> class EventListener : public EventListenerBase
 {
 public:
+    explicit EventListener(EventPolicy policy) : policy_(policy)
+    {
+    }
+
     // subscriber is responsible for managing the lifetime of the subscription. do not just get and destroy it.
     [[nodiscard]] std::unique_ptr<EventSubscription> Subscribe(std::function<void(Args...)> &&callback)
     {
+        ASSERT_F(policy_ == EventPolicy::Broadcast || callbacks_.empty(),
+                 "an exclusive event is already claimed. free it before binding again");
+
         auto id = AllocateId();
         callbacks_.emplace(id, std::move(callback));
 
@@ -123,13 +139,16 @@ private:
 
     std::unordered_map<uint32_t, std::function<void(Args...)>> callbacks_;
 
+    EventPolicy policy_;
+
     friend class Event<Args...>;
 };
 
 template <typename... Args> class Event
 {
 public:
-    Event() : listener_(std::make_shared<EventListener<Args...>>())
+    explicit Event(EventPolicy policy = EventPolicy::Broadcast)
+        : listener_(std::make_shared<EventListener<Args...>>(policy))
     {
     }
 

--- a/libraries/include/core/Event.h
+++ b/libraries/include/core/Event.h
@@ -12,15 +12,6 @@ namespace sparkle
 {
 class EventListenerBase;
 
-enum class EventPolicy : uint8_t
-{
-    // any number of listeners may observe the event
-    Broadcast,
-    // at most one listener at a time. use it for slots that represent ownership rather than
-    // observation, so that two owners cannot silently fight over the same signal.
-    Exclusive,
-};
-
 class EventSubscription
 {
 public:
@@ -106,16 +97,9 @@ template <typename... Args> class Event;
 template <typename... Args> class EventListener : public EventListenerBase
 {
 public:
-    explicit EventListener(EventPolicy policy) : policy_(policy)
-    {
-    }
-
     // subscriber is responsible for managing the lifetime of the subscription. do not just get and destroy it.
     [[nodiscard]] std::unique_ptr<EventSubscription> Subscribe(std::function<void(Args...)> &&callback)
     {
-        ASSERT_F(policy_ == EventPolicy::Broadcast || callbacks_.empty(),
-                 "an exclusive event is already claimed. free it before binding again");
-
         auto id = AllocateId();
         callbacks_.emplace(id, std::move(callback));
 
@@ -139,16 +123,13 @@ private:
 
     std::unordered_map<uint32_t, std::function<void(Args...)>> callbacks_;
 
-    EventPolicy policy_;
-
     friend class Event<Args...>;
 };
 
 template <typename... Args> class Event
 {
 public:
-    explicit Event(EventPolicy policy = EventPolicy::Broadcast)
-        : listener_(std::make_shared<EventListener<Args...>>(policy))
+    Event() : listener_(std::make_shared<EventListener<Args...>>())
     {
     }
 

--- a/libraries/include/renderer/RenderConfig.h
+++ b/libraries/include/renderer/RenderConfig.h
@@ -3,8 +3,12 @@
 #include "application/ConfigCollection.h"
 #include "renderer/RenderResolution.h"
 
+#include <memory>
+#include <vector>
+
 namespace sparkle
 {
+class EventSubscription;
 class RHIContext;
 class NativeView;
 
@@ -58,6 +62,10 @@ struct RenderConfig : public ConfigCollection
     }
 
     void Init();
+
+    // claims the manual-accumulation hold key. the caller owns the returned subscriptions: this
+    // struct is copied into every frame snapshot, so it cannot hold them itself.
+    [[nodiscard]] std::vector<std::unique_ptr<EventSubscription>> BindInput();
 
     [[nodiscard]] RenderResolution GetResolution() const
     {

--- a/libraries/include/scene/Scene.h
+++ b/libraries/include/scene/Scene.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/Event.h"
 #include "core/Exception.h"
 
 #include <atomic>
@@ -7,6 +8,7 @@
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 namespace sparkle
 {
@@ -141,5 +143,9 @@ private:
     SkyLight *sky_light_ = nullptr;
 
     std::shared_ptr<SceneAsyncTask::State> async_state_;
+
+    // scene input is claimed once for the scene's lifetime. the handlers resolve the scene state
+    // they act on at dispatch time, so loading another scene never rebinds them.
+    std::vector<std::unique_ptr<EventSubscription>> input_subscriptions_;
 };
 } // namespace sparkle

--- a/libraries/include/scene/SceneManager.h
+++ b/libraries/include/scene/SceneManager.h
@@ -3,8 +3,12 @@
 #include "core/Path.h"
 #include "core/task/TaskFuture.h"
 
+#include <memory>
+#include <vector>
+
 namespace sparkle
 {
+class EventSubscription;
 class Scene;
 class UiManager;
 
@@ -13,6 +17,10 @@ class SceneManager
 public:
     [[nodiscard]] static std::shared_ptr<TaskFuture<bool>> LoadScene(Scene *scene, const Path &asset_path,
                                                                      bool need_default_sky, bool need_default_lighting);
+
+    // claims the shortcuts that add and remove debug spheres. the scene owns the returned
+    // subscriptions.
+    [[nodiscard]] static std::vector<std::unique_ptr<EventSubscription>> BindDebugInput(Scene &scene);
 
     static void RemoveLastDebugSphere(Scene *scene);
 

--- a/libraries/include/scene/component/camera/CameraComponent.h
+++ b/libraries/include/scene/component/camera/CameraComponent.h
@@ -35,8 +35,6 @@ public:
 
     void UpdateRenderData();
 
-    virtual void PrintPosture() = 0;
-
 #pragma region Attributes
 
     [[nodiscard]] auto GetAttribute() const
@@ -46,29 +44,7 @@ public:
 
     void SetFocusDistance(float focus_distance);
 
-    void SetAperture(float aperture);
-
     void SetExposure(float exposure);
-
-#pragma endregion
-
-#pragma region Input
-
-    virtual void OnPointerDown()
-    {
-    }
-
-    virtual void OnPointerUp()
-    {
-    }
-
-    virtual void OnPointerMove(float, float)
-    {
-    }
-
-    virtual void OnScroll(float)
-    {
-    }
 
 #pragma endregion
 
@@ -79,6 +55,32 @@ public:
 #pragma endregion
 
 protected:
+#pragma region Input
+
+    // driven by the scene gestures BindSceneInput claims, never called from outside the camera
+
+    virtual void PrintPosture() = 0;
+
+    virtual void OnDragBegin()
+    {
+    }
+
+    virtual void OnDragEnd()
+    {
+    }
+
+    virtual void OnDrag(float, float)
+    {
+    }
+
+    virtual void OnZoom(float)
+    {
+    }
+
+    void SetAperture(float aperture);
+
+#pragma endregion
+
     std::unique_ptr<RenderProxy> CreateRenderProxy() override;
 
 private:

--- a/libraries/include/scene/component/camera/CameraComponent.h
+++ b/libraries/include/scene/component/camera/CameraComponent.h
@@ -2,8 +2,13 @@
 
 #include "scene/component/RenderableComponent.h"
 
+#include <vector>
+
 namespace sparkle
 {
+class EventSubscription;
+class Scene;
+
 class CameraComponent : public RenderableComponent
 {
 public:
@@ -22,6 +27,11 @@ public:
     explicit CameraComponent(const Attribute &attribute);
 
     ~CameraComponent() override;
+
+    // claims the scene input that drives camera posture and attributes. the scene owns the
+    // returned subscriptions; every handler resolves the scene's current main camera at
+    // dispatch time, so swapping the main camera needs no rebinding.
+    [[nodiscard]] static std::vector<std::unique_ptr<EventSubscription>> BindSceneInput(Scene &scene);
 
     void UpdateRenderData();
 

--- a/libraries/include/scene/component/camera/OrbitCameraComponent.h
+++ b/libraries/include/scene/component/camera/OrbitCameraComponent.h
@@ -54,17 +54,20 @@ public:
         SetupFromTransform();
     }
 
-    void OnPointerDown() override
+protected:
+    void PrintPosture() override;
+
+    void OnDragBegin() override
     {
         is_dragging_ = true;
     }
 
-    void OnPointerUp() override
+    void OnDragEnd() override
     {
         is_dragging_ = false;
     }
 
-    void OnPointerMove(float dx, float dy) override
+    void OnDrag(float dx, float dy) override
     {
         if (is_dragging_)
         {
@@ -75,7 +78,7 @@ public:
         }
     }
 
-    void OnScroll(float dx) override
+    void OnZoom(float dx) override
     {
         auto new_radius = std::clamp((1.f + dx * sensitivity_) * radius_, .001f, 100.f);
         if (std::abs(radius_ - new_radius) < Eps)
@@ -87,8 +90,6 @@ public:
 
         UpdateTransform();
     }
-
-    void PrintPosture() override;
 
 private:
     void UpdateTransform();

--- a/libraries/source/application/AppFramework.cpp
+++ b/libraries/source/application/AppFramework.cpp
@@ -18,14 +18,15 @@
 #include "rhi/RHI.h"
 #include "scene/Scene.h"
 #include "scene/SceneManager.h"
-#include "scene/component/camera/CameraComponent.h"
 #include "scene/material/MaterialManager.h"
 
 #if ENABLE_TEST_CASES
 #include "application/TestCase.h"
 #endif
 
+#include <algorithm>
 #include <cstring>
+#include <iterator>
 
 namespace sparkle
 {
@@ -509,16 +510,6 @@ void AppFramework::Cleanup()
     // no more logging should happen after this point
 }
 
-void AppFramework::DebugNextFrame()
-{
-    auto scale = view_->GetWindowScale();
-    auto pointer = input_manager_->GetPointerPosition();
-    TaskManager::RunInRenderThread([this, scale, pointer]() {
-        render_framework_->SetDebugPoint(pointer.x() * scale.x(),
-                                         static_cast<float>(render_config_.image_height) - pointer.y() * scale.y());
-    });
-}
-
 void AppFramework::PushInputEvent(const InputEvent &event)
 {
     if (input_manager_)
@@ -529,52 +520,6 @@ void AppFramework::PushInputEvent(const InputEvent &event)
 
 void AppFramework::SetupInputHandlers()
 {
-    input_subscriptions_.push_back(input_manager_->OnScenePointer().Subscribe([this](const PointerEvent &event) {
-        switch (event.action)
-        {
-        case PointerAction::Down:
-            if (event.button == ClickButton::SecondaryRight ||
-                (event.modifiers & static_cast<uint32_t>(KeyboardModifier::Control)))
-            {
-                DebugNextFrame();
-            }
-            else if (event.button == ClickButton::PrimaryLeft)
-            {
-                if (auto *camera = GetMainCamera())
-                {
-                    camera->OnPointerDown();
-                }
-            }
-            break;
-        case PointerAction::Up:
-        case PointerAction::Cancel:
-            if (event.button == ClickButton::PrimaryLeft)
-            {
-                if (auto *camera = GetMainCamera())
-                {
-                    camera->OnPointerUp();
-                }
-            }
-            break;
-        default:
-            break;
-        }
-    }));
-
-    input_subscriptions_.push_back(input_manager_->OnSceneDrag().Subscribe([this](Vector2 delta) {
-        if (auto *camera = GetMainCamera())
-        {
-            camera->OnPointerMove(delta.y(), -delta.x());
-        }
-    }));
-
-    input_subscriptions_.push_back(input_manager_->OnSceneZoom().Subscribe([this](float amount) {
-        if (auto *camera = GetMainCamera())
-        {
-            camera->OnScroll(amount);
-        }
-    }));
-
     input_subscriptions_.push_back(input_manager_->OnSceneDoubleTap().Subscribe(
         [this](uint8_t /*finger_count*/) { show_control_panel_ = !show_control_panel_; }));
 
@@ -585,8 +530,12 @@ void AppFramework::SetupInputHandlers()
         }
     }));
 
-    input_subscriptions_.push_back(
-        input_manager_->OnSceneKey().Subscribe([this](const KeyEvent &event) { HandleSceneKey(event); }));
+    input_subscriptions_.push_back(input_manager_->BindKey({.key = Key::Escape}, []() { RequestExit(); }));
+
+    // the app owns the config instance the per-frame snapshot is taken from, so it holds the
+    // subscriptions the renderer binds against it
+    auto render_config_subscriptions = render_config_.BindInput();
+    std::ranges::move(render_config_subscriptions, std::back_inserter(input_subscriptions_));
 }
 
 void AppFramework::ResetInputEvents()
@@ -605,96 +554,6 @@ void AppFramework::FrameBufferResizeCallback(int width, int height) const
             render_framework_->OnFrameBufferResize(width, height);
         }
     });
-}
-
-void AppFramework::HandleSceneKey(const KeyEvent &event)
-{
-    auto *camera = GetMainCamera();
-    if (!camera)
-    {
-        return;
-    }
-
-    Key key = event.key;
-#if FRAMEWORK_MACOS
-    // support keyboards with no escape key: the backspace key stands in for it
-    if (key == Key::Backspace)
-    {
-        key = Key::Escape;
-    }
-#endif
-
-    // Space is the only binding that tracks the key being held, so it reads the action itself;
-    // every other binding fires once on release. Shift is required where the glyph on the key
-    // needs it: Shift+Equal is the '+' a keyboard without a numpad has.
-    struct Binding
-    {
-        Key key;
-        bool needs_shift;
-        KeyAction action;
-        void (*handler)(AppFramework &app);
-    };
-
-    static constexpr Binding Bindings[] = {
-        {Key::Escape, false, KeyAction::Release, [](AppFramework &) { RequestExit(); }},
-        {Key::Space, false, KeyAction::Press, [](AppFramework &app) { app.HoldAccumulation(); }},
-        {Key::Space, false, KeyAction::Release, [](AppFramework &app) { app.ReleaseAccumulation(); }},
-        {Key::Up, false, KeyAction::Release, [](AppFramework &app) { app.WidenAperture(); }},
-        {Key::Down, false, KeyAction::Release, [](AppFramework &app) { app.NarrowAperture(); }},
-        {Key::P, false, KeyAction::Release, [](AppFramework &app) { app.PrintCameraPosture(); }},
-        {Key::NumpadAdd, false, KeyAction::Release, [](AppFramework &app) { app.AddDebugSphere(); }},
-        {Key::Equal, true, KeyAction::Release, [](AppFramework &app) { app.AddDebugSphere(); }},
-        {Key::Minus, false, KeyAction::Release, [](AppFramework &app) { app.RemoveDebugSphere(); }},
-    };
-
-    const bool shift_on = (event.modifiers & static_cast<uint32_t>(KeyboardModifier::Shift)) != 0;
-
-    for (const Binding &binding : Bindings)
-    {
-        if (binding.key == key && binding.action == event.action && (!binding.needs_shift || shift_on))
-        {
-            binding.handler(*this);
-        }
-    }
-}
-
-void AppFramework::HoldAccumulation()
-{
-    render_config_.accumulate_key_held = true;
-}
-
-void AppFramework::ReleaseAccumulation()
-{
-    render_config_.accumulate_key_held = false;
-}
-
-void AppFramework::WidenAperture() const
-{
-    auto *camera = GetMainCamera();
-    camera->SetAperture(camera->GetAttribute().aperture + 1.f);
-}
-
-void AppFramework::NarrowAperture() const
-{
-    auto *camera = GetMainCamera();
-    camera->SetAperture(camera->GetAttribute().aperture - 1.f);
-}
-
-void AppFramework::PrintCameraPosture() const
-{
-    GetMainCamera()->PrintPosture();
-}
-
-void AppFramework::AddDebugSphere()
-{
-    Log(Debug, "Add debug sphere");
-    SceneManager::GenerateRandomSpheres(*main_scene_, 1);
-}
-
-void AppFramework::RemoveDebugSphere()
-{
-    Log(Debug, "Remove debug sphere");
-    SceneManager::RemoveLastDebugSphere(main_scene_.get());
 }
 
 void AppFramework::RequestExit()

--- a/libraries/source/application/AppFramework.cpp
+++ b/libraries/source/application/AppFramework.cpp
@@ -530,7 +530,22 @@ void AppFramework::SetupInputHandlers()
         }
     }));
 
-    input_subscriptions_.push_back(input_manager_->BindKey({.key = Key::Escape}, []() { RequestExit(); }));
+    // escape has two owners: the panel dismisses itself first, and only a key it leaves alone
+    // reaches the app and exits
+    input_subscriptions_.push_back(input_manager_->BindKey(InputLayer::Ui, {.key = Key::Escape}, [this]() {
+        if (!show_control_panel_)
+        {
+            return false;
+        }
+
+        show_control_panel_ = false;
+        return true;
+    }));
+
+    input_subscriptions_.push_back(input_manager_->BindKey(InputLayer::Scene, {.key = Key::Escape}, []() {
+        RequestExit();
+        return true;
+    }));
 
     // the app owns the config instance the per-frame snapshot is taken from, so it holds the
     // subscriptions the renderer binds against it

--- a/libraries/source/application/InputManager.cpp
+++ b/libraries/source/application/InputManager.cpp
@@ -187,7 +187,7 @@ void InputManager::CancelScenePointer()
 
     primary_pressing_ = false;
 
-    scene_pointer_event_.Trigger(PointerEvent{.action = PointerAction::Cancel, .position = pointer_position_});
+    scene_drag_end_event_.Trigger();
 }
 
 void InputManager::HandleClick()
@@ -234,26 +234,28 @@ void InputManager::Process(const PointerEvent &event)
         {
             primary_pressing_ = true;
             click_timer_.Reset();
+            scene_drag_begin_event_.Trigger();
         }
-        scene_pointer_event_.Trigger(event);
+        else
+        {
+            scene_secondary_click_event_.Trigger(event.position);
+        }
         break;
     }
     case PointerAction::Up: {
-        const bool was_pressing = primary_pressing_;
-        if (event.button == ClickButton::PrimaryLeft)
+        if (event.button == ClickButton::PrimaryLeft && primary_pressing_)
         {
             primary_pressing_ = false;
-        }
-        scene_pointer_event_.Trigger(event);
-        if (event.button == ClickButton::PrimaryLeft && was_pressing &&
-            click_timer_.ElapsedMilliSecond() < ClickThresholdMS)
-        {
-            HandleClick();
+            scene_drag_end_event_.Trigger();
+
+            if (click_timer_.ElapsedMilliSecond() < ClickThresholdMS)
+            {
+                HandleClick();
+            }
         }
         break;
     }
     case PointerAction::Move: {
-        scene_pointer_event_.Trigger(event);
         if (primary_pressing_)
         {
             scene_drag_event_.Trigger(event.position - last_position);
@@ -269,13 +271,12 @@ void InputManager::Process(const PointerEvent &event)
     }
 }
 
-void InputManager::BeginTouchDrag(uint8_t id, const Vector2 &position)
+void InputManager::BeginTouchDrag()
 {
     primary_pressing_ = true;
     click_timer_.Reset();
 
-    scene_pointer_event_.Trigger(
-        PointerEvent{.device = PointerDevice::Touch, .action = PointerAction::Down, .id = id, .position = position});
+    scene_drag_begin_event_.Trigger();
 }
 
 void InputManager::ProcessTouch(const PointerEvent &event)
@@ -301,7 +302,7 @@ void InputManager::ProcessTouch(const PointerEvent &event)
             touch_.moved = false;
             if (!consumed)
             {
-                BeginTouchDrag(event.id, event.position);
+                BeginTouchDrag();
             }
         }
         else
@@ -341,7 +342,6 @@ void InputManager::ProcessTouch(const PointerEvent &event)
         }
         else if (primary_pressing_ && pointers.size() == 1)
         {
-            scene_pointer_event_.Trigger(event);
             scene_drag_event_.Trigger(event.position - previous);
         }
         break;
@@ -361,7 +361,7 @@ void InputManager::ProcessTouch(const PointerEvent &event)
             if (primary_pressing_)
             {
                 primary_pressing_ = false;
-                scene_pointer_event_.Trigger(event);
+                scene_drag_end_event_.Trigger();
             }
             if (tapped)
             {
@@ -380,7 +380,7 @@ void InputManager::ProcessTouch(const PointerEvent &event)
             touch_.pinching = false;
             if (!gate_.IsSequenceActive())
             {
-                BeginTouchDrag(pointers[0].id, pointers[0].position);
+                BeginTouchDrag();
             }
         }
         else if (touch_.pinching)

--- a/libraries/source/application/InputManager.cpp
+++ b/libraries/source/application/InputManager.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cfloat>
+#include <iterator>
 #include <utility>
 
 namespace sparkle
@@ -22,7 +23,16 @@ constexpr float TouchScrollStartDistance = 8.f;
 constexpr float PixelsPerWheelStep = 80.f;
 constexpr float PinchZoomScale = 0.1f;
 
+InputManager *InputManager::instance_ = nullptr;
+
 #if FRAMEWORK_MACOS
+// support keyboards with no escape key: the backspace key stands in for it. only key bindings
+// see the substitution, so text editing in the ui still receives a real backspace.
+static Key NormalizeBindingKey(Key key)
+{
+    return key == Key::Backspace ? Key::Escape : key;
+}
+
 // covers the keys imgui needs for widget interaction and text editing; printable input
 // arrives as CharEvent. only the macos framework needs it: every other framework feeds imgui
 // through its own backend (see FeedUiSystem below)
@@ -66,6 +76,28 @@ static ImGuiKey ToImGuiKey(Key key)
 InputManager::InputManager(const AppConfig &app_config, UiManager *ui_manager)
     : app_config_(app_config), ui_manager_(ui_manager)
 {
+    ASSERT(!instance_);
+
+    instance_ = this;
+}
+
+InputManager::~InputManager()
+{
+    instance_ = nullptr;
+}
+
+std::unique_ptr<EventSubscription> InputManager::BindKey(const KeyBinding &binding, std::function<void()> &&handler)
+{
+    ASSERT(ThreadManager::IsInMainThread());
+
+    auto found = std::ranges::find_if(key_bindings_, [&binding](const auto &slot) { return slot.first == binding; });
+    if (found == key_bindings_.end())
+    {
+        key_bindings_.emplace_back(binding, Event<>{EventPolicy::Exclusive});
+        found = std::prev(key_bindings_.end());
+    }
+
+    return found->second.OnTrigger().Subscribe(std::move(handler));
 }
 
 void InputManager::Push(const InputEvent &event)
@@ -362,6 +394,20 @@ void InputManager::Process(const KeyEvent &event)
     }
 
     scene_key_event_.Trigger(event);
+
+    Key key = event.key;
+#if FRAMEWORK_MACOS
+    key = NormalizeBindingKey(key);
+#endif
+
+    for (auto &[binding, slot] : key_bindings_)
+    {
+        if (binding.key == key && binding.action == event.action &&
+            (event.modifiers & binding.modifiers) == binding.modifiers)
+        {
+            slot.Trigger();
+        }
+    }
 }
 
 void InputManager::Process(const CharEvent &event)

--- a/libraries/source/application/InputManager.cpp
+++ b/libraries/source/application/InputManager.cpp
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 #include <cfloat>
-#include <iterator>
 #include <utility>
 
 namespace sparkle
@@ -86,18 +85,50 @@ InputManager::~InputManager()
     instance_ = nullptr;
 }
 
-std::unique_ptr<EventSubscription> InputManager::BindKey(const KeyBinding &binding, std::function<void()> &&handler)
+uint32_t InputManager::KeyBindings::Add(InputLayer layer, const KeyBinding &binding, KeyHandler &&handler)
+{
+    const bool claimed = std::ranges::any_of(
+        slots_, [layer, &binding](const Slot &slot) { return slot.layer == layer && slot.binding == binding; });
+    ASSERT_F(!claimed, "the key is already claimed in this layer. free it before binding again");
+
+    const auto id = AllocateId();
+
+    slots_.push_back({.layer = layer, .binding = binding, .handler = std::move(handler), .id = id});
+
+    return id;
+}
+
+bool InputManager::KeyBindings::Dispatch(InputLayer layer, const KeyEvent &event)
+{
+    auto found = std::ranges::find_if(slots_, [layer, &event](const Slot &slot) {
+        return slot.layer == layer && slot.binding.key == event.key && slot.binding.action == event.action &&
+               (event.modifiers & slot.binding.modifiers) == slot.binding.modifiers;
+    });
+    if (found == slots_.end())
+    {
+        return false;
+    }
+
+    // a handler may bind or free a slot, so it runs on a copy: mutating slots_ mid-dispatch
+    // must not invalidate the handler being called
+    KeyHandler handler = found->handler;
+
+    return handler();
+}
+
+bool InputManager::KeyBindings::RemoveCallback(uint32_t id)
+{
+    return std::erase_if(slots_, [id](const Slot &slot) { return slot.id == id; }) > 0;
+}
+
+std::unique_ptr<EventSubscription> InputManager::BindKey(InputLayer layer, const KeyBinding &binding,
+                                                         KeyHandler &&handler)
 {
     ASSERT(ThreadManager::IsInMainThread());
 
-    auto found = std::ranges::find_if(key_bindings_, [&binding](const auto &slot) { return slot.first == binding; });
-    if (found == key_bindings_.end())
-    {
-        key_bindings_.emplace_back(binding, Event<>{EventPolicy::Exclusive});
-        found = std::prev(key_bindings_.end());
-    }
+    const auto id = key_bindings_->Add(layer, binding, std::move(handler));
 
-    return found->second.OnTrigger().Subscribe(std::move(handler));
+    return std::make_unique<EventSubscription>(key_bindings_, id);
 }
 
 void InputManager::Push(const InputEvent &event)
@@ -393,19 +424,16 @@ void InputManager::Process(const KeyEvent &event)
         return;
     }
 
-    scene_key_event_.Trigger(event);
-
-    Key key = event.key;
+    KeyEvent binding_event = event;
 #if FRAMEWORK_MACOS
-    key = NormalizeBindingKey(key);
+    binding_event.key = NormalizeBindingKey(binding_event.key);
 #endif
 
-    for (auto &[binding, slot] : key_bindings_)
+    for (uint8_t layer = 0; layer < static_cast<uint8_t>(InputLayer::Count); layer++)
     {
-        if (binding.key == key && binding.action == event.action &&
-            (event.modifiers & binding.modifiers) == binding.modifiers)
+        if (key_bindings_->Dispatch(static_cast<InputLayer>(layer), binding_event))
         {
-            slot.Trigger();
+            break;
         }
     }
 }

--- a/libraries/source/application/RenderFramework.cpp
+++ b/libraries/source/application/RenderFramework.cpp
@@ -80,14 +80,8 @@ RenderFramework::RenderFramework(NativeView *native_view, RHIContext *rhi, UiMan
 
     if (auto *input_manager = InputManager::Instance())
     {
-        pointer_subscription_ = input_manager->OnScenePointer().Subscribe([this](const PointerEvent &event) {
-            const bool debug_gesture = event.button == ClickButton::SecondaryRight ||
-                                       (event.modifiers & static_cast<uint32_t>(KeyboardModifier::Control)) != 0;
-            if (event.action == PointerAction::Down && debug_gesture)
-            {
-                RequestDebugPoint(event.position);
-            }
-        });
+        secondary_click_subscription_ =
+            input_manager->OnSceneSecondaryClick().Subscribe([this](Vector2 position) { RequestDebugPoint(position); });
     }
 }
 

--- a/libraries/source/application/RenderFramework.cpp
+++ b/libraries/source/application/RenderFramework.cpp
@@ -1,5 +1,6 @@
 #include "application/RenderFramework.h"
 
+#include "application/InputManager.h"
 #include "application/NativeView.h"
 #include "application/UiManager.h"
 #include "core/CoreStates.h"
@@ -76,9 +77,32 @@ RenderFramework::RenderFramework(NativeView *native_view, RHIContext *rhi, UiMan
 {
     task_queue_ = std::make_shared<ThreadTaskQueue>();
     TaskDispatcher::Instance().RegisterTaskQueue(task_queue_, ThreadName::Render);
+
+    if (auto *input_manager = InputManager::Instance())
+    {
+        pointer_subscription_ = input_manager->OnScenePointer().Subscribe([this](const PointerEvent &event) {
+            const bool debug_gesture = event.button == ClickButton::SecondaryRight ||
+                                       (event.modifiers & static_cast<uint32_t>(KeyboardModifier::Control)) != 0;
+            if (event.action == PointerAction::Down && debug_gesture)
+            {
+                RequestDebugPoint(event.position);
+            }
+        });
+    }
 }
 
 RenderFramework::~RenderFramework() = default;
+
+void RenderFramework::RequestDebugPoint(const Vector2 &ui_position)
+{
+    const auto scale = native_view_->GetWindowScale();
+
+    TaskManager::RunInRenderThread([this, ui_position, scale]() {
+        // render_config_ belongs to the render thread, so the y flip reads the resolution here
+        SetDebugPoint(ui_position.x() * scale.x(),
+                      static_cast<float>(render_config_.image_height) - ui_position.y() * scale.y());
+    });
+}
 
 void RenderFramework::RenderThreadMain()
 {

--- a/libraries/source/renderer/RenderConfig.cpp
+++ b/libraries/source/renderer/RenderConfig.cpp
@@ -6,6 +6,7 @@
 #include "application/NativeView.h"
 #endif
 #include "application/ConfigCollectionHelper.h"
+#include "application/InputManager.h"
 
 namespace sparkle
 {
@@ -82,6 +83,24 @@ void RenderConfig::Init()
     });
 
     Validate();
+}
+
+std::vector<std::unique_ptr<EventSubscription>> RenderConfig::BindInput()
+{
+    auto *input_manager = InputManager::Instance();
+    if (!input_manager)
+    {
+        return {};
+    }
+
+    std::vector<std::unique_ptr<EventSubscription>> subscriptions;
+
+    subscriptions.push_back(input_manager->BindKey({.key = Key::Space, .action = KeyAction::Press},
+                                                   [this]() { accumulate_key_held = true; }));
+    subscriptions.push_back(input_manager->BindKey({.key = Key::Space, .action = KeyAction::Release},
+                                                   [this]() { accumulate_key_held = false; }));
+
+    return subscriptions;
 }
 
 static RenderConfig::Pipeline GetFallbackRenderMode(RenderConfig::Pipeline mode)

--- a/libraries/source/renderer/RenderConfig.cpp
+++ b/libraries/source/renderer/RenderConfig.cpp
@@ -95,10 +95,16 @@ std::vector<std::unique_ptr<EventSubscription>> RenderConfig::BindInput()
 
     std::vector<std::unique_ptr<EventSubscription>> subscriptions;
 
-    subscriptions.push_back(input_manager->BindKey({.key = Key::Space, .action = KeyAction::Press},
-                                                   [this]() { accumulate_key_held = true; }));
-    subscriptions.push_back(input_manager->BindKey({.key = Key::Space, .action = KeyAction::Release},
-                                                   [this]() { accumulate_key_held = false; }));
+    subscriptions.push_back(
+        input_manager->BindKey(InputLayer::Scene, {.key = Key::Space, .action = KeyAction::Press}, [this]() {
+            accumulate_key_held = true;
+            return true;
+        }));
+    subscriptions.push_back(
+        input_manager->BindKey(InputLayer::Scene, {.key = Key::Space, .action = KeyAction::Release}, [this]() {
+            accumulate_key_held = false;
+            return true;
+        }));
 
     return subscriptions;
 }

--- a/libraries/source/scene/Scene.cpp
+++ b/libraries/source/scene/Scene.cpp
@@ -5,12 +5,14 @@
 #include "core/task/TaskManager.h"
 #include "renderer/proxy/MaterialRenderProxy.h"
 #include "renderer/proxy/SceneRenderProxy.h"
+#include "scene/SceneManager.h"
 #include "scene/SceneNode.h"
 #include "scene/component/camera/CameraComponent.h"
 #include "scene/component/light/SkyLight.h"
 #include "scene/component/primitive/PrimitiveComponent.h"
 #include "scene/material/Material.h"
 
+#include <iterator>
 #include <queue>
 #include <ranges>
 
@@ -57,6 +59,10 @@ Scene::Scene()
     : render_proxy_(CreateRenderProxy()), root_node_(std::make_unique<SceneNode>(this, "SceneRoot")),
       async_state_(std::make_shared<SceneAsyncTask::State>())
 {
+    input_subscriptions_ = CameraComponent::BindSceneInput(*this);
+
+    auto debug_subscriptions = SceneManager::BindDebugInput(*this);
+    std::ranges::move(debug_subscriptions, std::back_inserter(input_subscriptions_));
 }
 
 Scene::~Scene()

--- a/libraries/source/scene/SceneManager.cpp
+++ b/libraries/source/scene/SceneManager.cpp
@@ -206,19 +206,22 @@ std::vector<std::unique_ptr<EventSubscription>> SceneManager::BindDebugInput(Sce
     auto add_sphere = [&scene]() {
         Log(Debug, "Add debug sphere");
         GenerateRandomSpheres(scene, 1);
+        return true;
     };
 
     std::vector<std::unique_ptr<EventSubscription>> subscriptions;
 
-    subscriptions.push_back(input_manager->BindKey({.key = Key::NumpadAdd}, add_sphere));
+    subscriptions.push_back(input_manager->BindKey(InputLayer::Scene, {.key = Key::NumpadAdd}, add_sphere));
 
     // shift + equal is the '+' a keyboard without a numpad has
     subscriptions.push_back(input_manager->BindKey(
-        {.key = Key::Equal, .modifiers = static_cast<uint32_t>(KeyboardModifier::Shift)}, add_sphere));
+        InputLayer::Scene, {.key = Key::Equal, .modifiers = static_cast<uint32_t>(KeyboardModifier::Shift)},
+        add_sphere));
 
-    subscriptions.push_back(input_manager->BindKey({.key = Key::Minus}, [&scene]() {
+    subscriptions.push_back(input_manager->BindKey(InputLayer::Scene, {.key = Key::Minus}, [&scene]() {
         Log(Debug, "Remove debug sphere");
         RemoveLastDebugSphere(&scene);
+        return true;
     }));
 
     return subscriptions;

--- a/libraries/source/scene/SceneManager.cpp
+++ b/libraries/source/scene/SceneManager.cpp
@@ -1,5 +1,6 @@
 #include "scene/SceneManager.h"
 
+#include "application/InputManager.h"
 #include "core/ConfigManager.h"
 #include "core/FileManager.h"
 #include "core/Logger.h"
@@ -183,10 +184,44 @@ std::shared_ptr<TaskFuture<bool>> SceneManager::LoadScene(Scene *scene, const Pa
 
 void SceneManager::RemoveLastDebugSphere(Scene *scene)
 {
+    if (debug_spheres.empty())
+    {
+        return;
+    }
+
     auto *root_node = scene->GetRootNode();
     auto *last_sphere = debug_spheres.back();
     root_node->RemoveChild(last_sphere);
     debug_spheres.pop_back();
+}
+
+std::vector<std::unique_ptr<EventSubscription>> SceneManager::BindDebugInput(Scene &scene)
+{
+    auto *input_manager = InputManager::Instance();
+    if (!input_manager)
+    {
+        return {};
+    }
+
+    auto add_sphere = [&scene]() {
+        Log(Debug, "Add debug sphere");
+        GenerateRandomSpheres(scene, 1);
+    };
+
+    std::vector<std::unique_ptr<EventSubscription>> subscriptions;
+
+    subscriptions.push_back(input_manager->BindKey({.key = Key::NumpadAdd}, add_sphere));
+
+    // shift + equal is the '+' a keyboard without a numpad has
+    subscriptions.push_back(input_manager->BindKey(
+        {.key = Key::Equal, .modifiers = static_cast<uint32_t>(KeyboardModifier::Shift)}, add_sphere));
+
+    subscriptions.push_back(input_manager->BindKey({.key = Key::Minus}, [&scene]() {
+        Log(Debug, "Remove debug sphere");
+        RemoveLastDebugSphere(&scene);
+    }));
+
+    return subscriptions;
 }
 
 std::shared_ptr<TaskFuture<void>> SceneManager::AddDefaultSky(Scene *scene)

--- a/libraries/source/scene/component/camera/CameraComponent.cpp
+++ b/libraries/source/scene/component/camera/CameraComponent.cpp
@@ -28,42 +28,32 @@ std::vector<std::unique_ptr<EventSubscription>> CameraComponent::BindSceneInput(
 
     std::vector<std::unique_ptr<EventSubscription>> subscriptions;
 
-    subscriptions.push_back(input_manager->OnScenePointer().Subscribe([&scene](const PointerEvent &event) {
-        auto *camera = scene.GetMainCamera();
-        if (!camera || event.button != ClickButton::PrimaryLeft)
+    subscriptions.push_back(input_manager->OnSceneDragBegin().Subscribe([&scene]() {
+        if (auto *camera = scene.GetMainCamera())
         {
-            return;
-        }
-
-        switch (event.action)
-        {
-        case PointerAction::Down:
-            // control + primary is the debug-point gesture, so it must not start a camera drag
-            if ((event.modifiers & static_cast<uint32_t>(KeyboardModifier::Control)) == 0)
-            {
-                camera->OnPointerDown();
-            }
-            break;
-        case PointerAction::Up:
-        case PointerAction::Cancel:
-            camera->OnPointerUp();
-            break;
-        default:
-            break;
+            camera->OnDragBegin();
         }
     }));
 
+    subscriptions.push_back(input_manager->OnSceneDragEnd().Subscribe([&scene]() {
+        if (auto *camera = scene.GetMainCamera())
+        {
+            camera->OnDragEnd();
+        }
+    }));
+
+    // a drag along x orbits around the vertical axis, so the deltas cross over
     subscriptions.push_back(input_manager->OnSceneDrag().Subscribe([&scene](Vector2 delta) {
         if (auto *camera = scene.GetMainCamera())
         {
-            camera->OnPointerMove(delta.y(), -delta.x());
+            camera->OnDrag(delta.y(), -delta.x());
         }
     }));
 
     subscriptions.push_back(input_manager->OnSceneZoom().Subscribe([&scene](float amount) {
         if (auto *camera = scene.GetMainCamera())
         {
-            camera->OnScroll(amount);
+            camera->OnZoom(amount);
         }
     }));
 

--- a/libraries/source/scene/component/camera/CameraComponent.cpp
+++ b/libraries/source/scene/component/camera/CameraComponent.cpp
@@ -1,5 +1,6 @@
 #include "scene/component/camera/CameraComponent.h"
 
+#include "application/InputManager.h"
 #include "core/Logger.h"
 #include "core/task/TaskManager.h"
 #include "renderer/proxy/CameraRenderProxy.h"
@@ -8,11 +9,85 @@
 
 namespace sparkle
 {
+// one f-stop per key press
+constexpr float ApertureStep = 1.f;
+
 CameraComponent::CameraComponent(const Attribute &attribute) : attribute_(attribute)
 {
 }
 
 CameraComponent::~CameraComponent() = default;
+
+std::vector<std::unique_ptr<EventSubscription>> CameraComponent::BindSceneInput(Scene &scene)
+{
+    auto *input_manager = InputManager::Instance();
+    if (!input_manager)
+    {
+        return {};
+    }
+
+    std::vector<std::unique_ptr<EventSubscription>> subscriptions;
+
+    subscriptions.push_back(input_manager->OnScenePointer().Subscribe([&scene](const PointerEvent &event) {
+        auto *camera = scene.GetMainCamera();
+        if (!camera || event.button != ClickButton::PrimaryLeft)
+        {
+            return;
+        }
+
+        switch (event.action)
+        {
+        case PointerAction::Down:
+            // control + primary is the debug-point gesture, so it must not start a camera drag
+            if ((event.modifiers & static_cast<uint32_t>(KeyboardModifier::Control)) == 0)
+            {
+                camera->OnPointerDown();
+            }
+            break;
+        case PointerAction::Up:
+        case PointerAction::Cancel:
+            camera->OnPointerUp();
+            break;
+        default:
+            break;
+        }
+    }));
+
+    subscriptions.push_back(input_manager->OnSceneDrag().Subscribe([&scene](Vector2 delta) {
+        if (auto *camera = scene.GetMainCamera())
+        {
+            camera->OnPointerMove(delta.y(), -delta.x());
+        }
+    }));
+
+    subscriptions.push_back(input_manager->OnSceneZoom().Subscribe([&scene](float amount) {
+        if (auto *camera = scene.GetMainCamera())
+        {
+            camera->OnScroll(amount);
+        }
+    }));
+
+    auto bind_aperture_step = [input_manager, &scene, &subscriptions](Key key, float step) {
+        subscriptions.push_back(input_manager->BindKey({.key = key}, [&scene, step]() {
+            if (auto *camera = scene.GetMainCamera())
+            {
+                camera->SetAperture(camera->GetAttribute().aperture + step);
+            }
+        }));
+    };
+
+    bind_aperture_step(Key::Up, ApertureStep);
+    bind_aperture_step(Key::Down, -ApertureStep);
+
+    subscriptions.push_back(input_manager->BindKey({.key = Key::P}, [&scene]() {
+        if (auto *camera = scene.GetMainCamera())
+        {
+            camera->PrintPosture();
+        }
+    }));
+
+    return subscriptions;
+}
 
 void CameraComponent::SetExposure(float exposure)
 {

--- a/libraries/source/scene/component/camera/CameraComponent.cpp
+++ b/libraries/source/scene/component/camera/CameraComponent.cpp
@@ -68,22 +68,30 @@ std::vector<std::unique_ptr<EventSubscription>> CameraComponent::BindSceneInput(
     }));
 
     auto bind_aperture_step = [input_manager, &scene, &subscriptions](Key key, float step) {
-        subscriptions.push_back(input_manager->BindKey({.key = key}, [&scene, step]() {
-            if (auto *camera = scene.GetMainCamera())
+        subscriptions.push_back(input_manager->BindKey(InputLayer::Scene, {.key = key}, [&scene, step]() {
+            auto *camera = scene.GetMainCamera();
+            if (!camera)
             {
-                camera->SetAperture(camera->GetAttribute().aperture + step);
+                return false;
             }
+
+            camera->SetAperture(camera->GetAttribute().aperture + step);
+            return true;
         }));
     };
 
     bind_aperture_step(Key::Up, ApertureStep);
     bind_aperture_step(Key::Down, -ApertureStep);
 
-    subscriptions.push_back(input_manager->BindKey({.key = Key::P}, [&scene]() {
-        if (auto *camera = scene.GetMainCamera())
+    subscriptions.push_back(input_manager->BindKey(InputLayer::Scene, {.key = Key::P}, [&scene]() {
+        auto *camera = scene.GetMainCamera();
+        if (!camera)
         {
-            camera->PrintPosture();
+            return false;
         }
+
+        camera->PrintPosture();
+        return true;
     }));
 
     return subscriptions;

--- a/tests/input/InputInjectionTest.cpp
+++ b/tests/input/InputInjectionTest.cpp
@@ -105,6 +105,12 @@ private:
         app.PushInputEvent(PointerEvent{.action = PointerAction::Up, .position = position});
     }
 
+    static void InjectKey(AppFramework &app, Key key)
+    {
+        app.PushInputEvent(KeyEvent{.key = key, .action = KeyAction::Press});
+        app.PushInputEvent(KeyEvent{.key = key, .action = KeyAction::Release});
+    }
+
     void BuildSteps()
     {
         const Vector2 start{400.f, 300.f};
@@ -146,9 +152,7 @@ private:
                               [this](AppFramework &app) {
                                   // the default aperture sits at the clamp maximum, so step downwards
                                   aperture_before_ = camera_->GetAttribute().aperture;
-                                  const Key key = Key::Down;
-                                  app.PushInputEvent(KeyEvent{.key = key, .action = KeyAction::Press});
-                                  app.PushInputEvent(KeyEvent{.key = key, .action = KeyAction::Release});
+                                  InjectKey(app, Key::Down);
                               },
                           .verify =
                               [this](AppFramework &) {
@@ -167,6 +171,50 @@ private:
                                   app.PushInputEvent(KeyEvent{.key = Key::Space, .action = KeyAction::Release});
                               },
                           .verify = [](AppFramework &app) { return !app.GetRenderConfig().accumulate_key_held; }});
+
+        // two owners of one key, arbitrated by layer. ArbitrationKey is bound by no module, so
+        // these two bindings are the only claims on it.
+        steps_.push_back({.name = "the ui layer answers a key before the scene",
+                          .inject =
+                              [this](AppFramework &app) {
+                                  auto *input_manager = app.GetInputManager();
+                                  ui_consumes_ = true;
+                                  ui_fired_ = false;
+                                  scene_fired_ = false;
+                                  ui_binding_ =
+                                      input_manager->BindKey(InputLayer::Ui, {.key = ArbitrationKey}, [this]() {
+                                          ui_fired_ = true;
+                                          return ui_consumes_;
+                                      });
+                                  scene_binding_ =
+                                      input_manager->BindKey(InputLayer::Scene, {.key = ArbitrationKey}, [this]() {
+                                          scene_fired_ = true;
+                                          return true;
+                                      });
+                                  InjectKey(app, ArbitrationKey);
+                              },
+                          .verify = [this](AppFramework &) { return ui_fired_ && !scene_fired_; }});
+
+        steps_.push_back({.name = "a ui binding that declines lets the scene have the key",
+                          .inject =
+                              [this](AppFramework &app) {
+                                  ui_consumes_ = false;
+                                  ui_fired_ = false;
+                                  scene_fired_ = false;
+                                  InjectKey(app, ArbitrationKey);
+                              },
+                          .verify = [this](AppFramework &) { return ui_fired_ && scene_fired_; }});
+
+        steps_.push_back({.name = "freeing a binding releases its key",
+                          .inject =
+                              [this](AppFramework &app) {
+                                  ui_binding_.reset();
+                                  scene_binding_.reset();
+                                  ui_fired_ = false;
+                                  scene_fired_ = false;
+                                  InjectKey(app, ArbitrationKey);
+                              },
+                          .verify = [this](AppFramework &) { return !ui_fired_ && !scene_fired_; }});
 
         auto touch = [](PointerAction action, uint8_t id, const Vector2 &position) {
             return PointerEvent{.device = PointerDevice::Touch, .action = action, .id = id, .position = position};
@@ -235,6 +283,9 @@ private:
              .verify = [this](AppFramework &app) { return app.IsControlPanelVisible() != panel_before_; }});
     }
 
+    // claimed by no module, so the layer steps own it outright
+    static constexpr Key ArbitrationKey = Key::T;
+
     std::vector<Step> steps_;
     size_t current_step_ = 0;
     bool pending_verify_ = false;
@@ -247,6 +298,12 @@ private:
     bool panel_before_ = false;
     uint8_t last_tap_fingers_ = 0;
     std::unique_ptr<EventSubscription> tap_subscription_;
+
+    bool ui_consumes_ = false;
+    bool ui_fired_ = false;
+    bool scene_fired_ = false;
+    std::unique_ptr<EventSubscription> ui_binding_;
+    std::unique_ptr<EventSubscription> scene_binding_;
 };
 
 static TestCaseRegistrar<InputInjectionTest> input_injection_test_registrar("input_injection");


### PR DESCRIPTION
`AppFramework` implemented and registered every input handler, including ones that belong to other modules: camera posture and aperture, the render config accumulation hold, the renderer debug point, and the debug spheres. Every module now claims its own input through `InputManager`, reachable via `InputManager::Instance()` so no app-layer wiring is needed.

## Scene events are gestures, not pointers

`OnScenePointer` handed subscribers a raw `PointerEvent`, so each one re-derived the gesture it wanted: the camera asked whether the button was primary and control was up before starting a drag, the renderer asked whether it was secondary or control + primary before placing a debug point. `InputManager` already computes both — it needs them for its own press tracking. Recognition now happens there once:

| scene event | mouse | touch |
| --- | --- | --- |
| `OnSceneDragBegin` / `OnSceneDrag(delta)` / `OnSceneDragEnd` | primary pressed and moving | one finger |
| `OnSceneZoom(amount)` | wheel | pinch |
| `OnSceneSecondaryClick(position)` | secondary button, or control + primary | — |
| `OnSceneTap(finger_count)` | — | quick tap, no slop |
| `OnSceneDoubleTap(finger_count)` | double click | double tap |

`OnSceneDragEnd` is guaranteed — it also fires when the ui takes a sequence over mid-drag — so an owner that acted on `Begin` can rely on `End` and never has to know `PointerAction::Cancel` exists. Scene events stay broadcast: any number of modules may observe one.

## Keys are arbitrated by layer

A key often means different things to different modules — `Escape` dismisses the config panel, and it also exits the app — so a single owner per key is not enough. `BindKey(InputLayer, KeyBinding, handler)`:

* Layers answer a key in declaration order (`Ui`, then `Scene`), and a handler returns `true` to consume it, which stops lower layers from seeing it.
* An owner that is currently irrelevant — a panel that is closed — returns `false`, and the key falls through as if the binding did not exist. Nothing has to bind and unbind as ui state changes.
* Within one layer a key has exactly one owner; a second claim in the same layer asserts. Two owners in one layer have no defined order, whereas two owners in different layers do.
* Dispatch loops over the enum, so a new layer needs only a new enumerator.

The registry holds one consuming handler per slot, which a broadcast `Event` cannot express, and reuses `EventSubscription` so a binding's lifetime works exactly like an event subscription's. `Event` itself is untouched.

While imgui wants the keyboard (a focused text field) no binding runs in any layer — imgui owns the keystroke.

## Ownership after the move

| input | layer | owner |
| --- | --- | --- |
| drag, zoom, `Up`/`Down` (aperture), `P` (print posture) | `Scene` | `CameraComponent::BindSceneInput` |
| `Space` hold (manual accumulation) | `Scene` | `RenderConfig::BindInput` |
| secondary click (debug point) | — | `RenderFramework` |
| `NumpadAdd` / `Shift`+`Equal` / `Minus` (debug spheres) | `Scene` | `SceneManager::BindDebugInput` |
| `Escape` (dismiss the config panel) | `Ui` | `AppFramework` |
| `Escape` (exit), double tap (config panel), 4-finger tap (frame capture) | `Scene` | `AppFramework` |

Two constraints shaped the design:

* Scene loading calls `SetMainCamera` off the main thread (the USD loader runs on a dedicated thread), so per-camera rebinding would race the main-thread dispatch. The camera bindings are instead claimed once for the `Scene`'s lifetime and resolve `GetMainCamera()` at dispatch — thread-safe, and the per-layer claim holds across camera swaps.
* `RenderConfig` is copied into every frame snapshot, so it cannot hold subscriptions. `BindInput()` returns them for `AppFramework` — which owns the config instance — to hold, while the handler stays in the renderer.

## API removed

* `OnScenePointer` and `OnSceneKey`. `PointerEvent` now stops at `InputManager`: no module outside it handles a raw pointer, or names `ClickButton` or `KeyboardModifier`.
* `CameraComponent::OnPointerDown` / `OnPointerUp` / `OnPointerMove` / `OnScroll` become `OnDragBegin` / `OnDragEnd` / `OnDrag` / `OnZoom`, and those, `PrintPosture` and `SetAperture` are now protected — the only caller is the camera's own `BindSceneInput`.
* `RenderFramework::SetDebugPoint` is private, and `InputManager::GetPointerPosition` is gone.

Two gaps are left deliberately, because nothing consumes them: there is no primary click/tap event for the mouse (`OnSceneTap` stays touch-only), and touch has no secondary gesture, so the debug point is desktop-only. A 2-finger tap is already recognized and would map to `OnSceneSecondaryClick` naturally if that is wanted.

## Behavior changes

* `Escape` now dismisses the config panel when it is open, and exits only when it is not. This is the first user of the `Ui` layer.
* `Backspace`→`Escape` normalization moved into `InputManager`, so it covers every binding rather than only the ones the app dispatched.
* Shortcuts no longer silently require a main camera to exist (previously `Escape` and the accumulation hold did).
* The debug-point y flip reads the render thread's own resolution instead of the main thread's config copy.
* `RemoveLastDebugSphere` no longer indexes an empty list.

## Validation

`input_injection` gains three steps for the key arbitration, using a key no module claims: the ui layer consumes and the scene does not see it; the ui layer declines and the scene gets it; both bindings freed and neither fires. Its existing steps (drag, zoom, double tap, aperture key, space hold) cover the rewired gesture paths on both mouse and touch.

A full build was not possible in the development environment (no Vulkan SDK or GLFW, submodules not checked out). Locally each commit was checked with `-fsyntax-only` over every `.cpp` in `libraries/source` and `tests`, the project warning set (`-Wall -Wextra -Wpedantic -Werror` plus the extras), `clang-tidy` with the project config, and `dev/check_format.py` — all clean on the changed files. The available clang-tidy was major 18 while CI pins major 22, and `dev/run_tests.py` needs a build, so both of those gates were left to CI, where they pass.
