### PR TITLE
[Cook] batch the BC6H refine through CVTT's parallel block lanes

### DIFF
--- a/libraries/source/io/TextureCompression.cpp
+++ b/libraries/source/io/TextureCompression.cpp
@@ -344,15 +344,9 @@ float Bc6hTexelToFloat(int16_t bits)
     return static_cast<float>(std::bit_cast<Half>(bits));
 }
 
-// absolute rgb error of one encoded block against its source texels, and the signal it
-// carries, both through the spec-exact decode
-std::pair<double, double> Bc6hBlockError(const cvtt::PixelBlockF16 &source, const uint8_t *encoded)
+// absolute rgb error of one decoded block against its source texels, and the signal it carries
+std::pair<double, double> Bc6hBlockError(const cvtt::PixelBlockF16 &source, const cvtt::PixelBlockF16 &decoded)
 {
-    std::array<cvtt::PixelBlockF16, cvtt::NumParallelBlocks> decoded{};
-    std::array<uint8_t, cvtt::NumParallelBlocks * 16> batch{};
-    std::memcpy(batch.data(), encoded, 16);
-    cvtt::Kernels::DecodeBC6HU(decoded.data(), batch.data());
-
     double error = 0.0;
     double signal = 0.0;
     for (unsigned texel = 0; texel < 16; texel++)
@@ -360,7 +354,7 @@ std::pair<double, double> Bc6hBlockError(const cvtt::PixelBlockF16 &source, cons
         for (unsigned channel = 0; channel < 3; channel++)
         {
             const float reference = Bc6hTexelToFloat(source.m_pixels[texel][channel]);
-            const float restored = Bc6hTexelToFloat(decoded[0].m_pixels[texel][channel]);
+            const float restored = Bc6hTexelToFloat(decoded.m_pixels[texel][channel]);
             error += std::abs(restored - reference);
             signal += std::abs(reference);
         }
@@ -416,29 +410,67 @@ void EncodeBc6hMip(const uint8_t *fp16, unsigned width, unsigned height, uint8_t
     const unsigned blocks_x = padded_width / block_dim;
     const unsigned blocks_y = padded_height / block_dim;
     const auto options = Bc6hOptions();
+    const size_t total_blocks = static_cast<size_t>(blocks_x) * blocks_y;
 
-    for (unsigned by = 0; by < blocks_y; by++)
+    // every CVTT kernel call carries NumParallelBlocks blocks whatever it is handed, and on the
+    // scalar path that is that many independent passes over the block. so both halves of this
+    // work in whole batches: the survey below decodes NumParallelBlocks blocks per call, and the
+    // refine collects its candidates and searches them together rather than one block per call
+    // against seven copies of itself. the candidates are a fraction of a percent of the mip but
+    // the exhaustive search is thousands of times the cost of the decode that finds them, so
+    // grouping them is what this pass costs
+    std::array<cvtt::PixelBlockF16, cvtt::NumParallelBlocks> sources{};
+    std::array<cvtt::PixelBlockF16, cvtt::NumParallelBlocks> decoded{};
+    std::array<uint8_t, cvtt::NumParallelBlocks * 16> batch{};
+
+    std::vector<cvtt::PixelBlockF16> candidate_sources;
+    std::vector<size_t> candidate_indices;
+    std::vector<double> candidate_errors;
+
+    for (size_t batch_start = 0; batch_start < total_blocks; batch_start += cvtt::NumParallelBlocks)
     {
-        for (unsigned bx = 0; bx < blocks_x; bx++)
+        const size_t batch_size = std::min<size_t>(cvtt::NumParallelBlocks, total_blocks - batch_start);
+        for (size_t lane = 0; lane < batch_size; lane++)
         {
-            cvtt::PixelBlockF16 source{};
-            GatherBc6hBlock(pixels, padded_width, padded_height, bx, by, source);
+            const size_t index = batch_start + lane;
+            GatherBc6hBlock(pixels, padded_width, padded_height, static_cast<unsigned>(index % blocks_x),
+                            static_cast<unsigned>(index / blocks_x), sources[lane]);
+            std::memcpy(batch.data() + lane * 16, out + index * 16, 16);
+        }
+        cvtt::Kernels::DecodeBC6HU(decoded.data(), batch.data());
 
-            uint8_t *block = out + ((static_cast<size_t>(by) * blocks_x) + bx) * 16;
-            const auto [error, signal] = Bc6hBlockError(source, block);
-            if (signal <= 0.0 || error <= signal * RefineErrorThreshold)
+        for (size_t lane = 0; lane < batch_size; lane++)
+        {
+            const auto [error, signal] = Bc6hBlockError(sources[lane], decoded[lane]);
+            if (signal > 0.0 && error > signal * RefineErrorThreshold)
             {
-                continue;
+                candidate_sources.push_back(sources[lane]);
+                candidate_indices.push_back(batch_start + lane);
+                candidate_errors.push_back(error);
             }
+        }
+    }
 
-            std::array<cvtt::PixelBlockF16, cvtt::NumParallelBlocks> blocks{};
-            blocks.fill(source);
-            std::array<uint8_t, cvtt::NumParallelBlocks * 16> encoded;
-            cvtt::Kernels::EncodeBC6HU(encoded.data(), blocks.data(), options);
+    // the trailing lanes of the last batch repeat its final candidate: the kernel encodes all
+    // NumParallelBlocks either way, and only the lanes a candidate claims are read back
+    for (size_t start = 0; start < candidate_sources.size(); start += cvtt::NumParallelBlocks)
+    {
+        const size_t count = std::min<size_t>(cvtt::NumParallelBlocks, candidate_sources.size() - start);
+        std::array<cvtt::PixelBlockF16, cvtt::NumParallelBlocks> blocks{};
+        for (size_t lane = 0; lane < cvtt::NumParallelBlocks; lane++)
+        {
+            blocks[lane] = candidate_sources[start + std::min(lane, count - 1)];
+        }
 
-            if (Bc6hBlockError(source, encoded.data()).first < error)
+        std::array<uint8_t, cvtt::NumParallelBlocks * 16> encoded;
+        cvtt::Kernels::EncodeBC6HU(encoded.data(), blocks.data(), options);
+        cvtt::Kernels::DecodeBC6HU(decoded.data(), encoded.data());
+
+        for (size_t lane = 0; lane < count; lane++)
+        {
+            if (Bc6hBlockError(candidate_sources[start + lane], decoded[lane]).first < candidate_errors[start + lane])
             {
-                std::memcpy(block, encoded.data(), 16);
+                std::memcpy(out + candidate_indices[start + lane] * 16, encoded.data() + lane * 16, 16);
             }
         }
     }


### PR DESCRIPTION
Every CVTT kernel call carries `NumParallelBlocks` blocks whatever it is handed, and on the scalar path that is that many independent passes. The refine called it one block at a time in both directions: the survey decoded a single block against seven zero-filled lanes, and each candidate ran the exhaustive search against seven copies of itself.

Both now work in whole batches — the survey decodes `NumParallelBlocks` blocks per call, and the candidates it collects are searched together, so the kernel call count drops from one per candidate to one per eight.

## Effect on the cook node

Measured on the `cook (ubuntu-latest, glfw, Release)` node, before ([run 30214428872](https://github.com/tqjxlm/Sparkle/actions/runs/30214428872)) against after ([run 30220582522](https://github.com/tqjxlm/Sparkle/actions/runs/30220582522)):

| cook job | before | after | |
|---|---|---|---|
| `skylight_bc` | 188.2s | **27.2s** | 6.9x |
| `ibl_specular_bc` | 125.7s | **25.2s** | 5.0x |
| `ibl_diffuse_bc` | 1.4s | 1.5s | — |
| whole node | 6m48s | **2m32s** | 2.7x |

Those two cube jobs were 93% of the step, so the node drops by roughly 4m15s. Since `cook-bc` gates the windows and linux release and test nodes, that comes off the pipeline's critical path on every run.

## Why it is this large

Candidates — blocks whose ispc encoding misses badly enough to re-search — are a small fraction of the mip, but their exhaustive search is 89-99% of the pass, the survey decode being roughly a thousandth of one search. Batching them is therefore the whole cost of the pass.

An offline harness over a synthetic sky face put candidates at 0.2-0.8% of blocks and predicted a smaller win:

| | blocks | candidates | before | after | |
|---|---|---|---|---|---|
| 64x64 | 256 | 2 (0.78%) | 10.2 ms | 5.1 ms | 2.0x |
| 128x128 | 1024 | 4 (0.39%) | 24.4 ms | 6.1 ms | 4.0x |
| 256x256 | 4096 | 9 (0.22%) | 51.4 ms | 11.4 ms | 4.5x |

Real captured HDR (`studio_garden.hdr`) evidently produces a far higher candidate rate than that synthetic gradient-plus-sun-disk, which is why the CI numbers beat the harness. The synthetic face understated how much of the cook was sitting in the refine.

## Output is unchanged

`EncodeBC6HU` and `DecodeBC6HU` both dispatch each lane through an independent `Pack`/`UnpackOne`, so a batch of distinct blocks encodes and decodes exactly as those blocks did alone. Two independent confirmations:

- the harness runs this implementation against the previous one and reports byte-identical blocks on every case
- `test (windows-latest, glfw, Release)` and `test (ubuntu-latest, glfw, Release)` — the two cells that consume the BC content images this node produces — pass against unmodified screenshot ground truth

## Still on the table

`GetProfile_bc6h_slow` → `bc6h_basic` (`fastSkipTreshold` 10→4, `slow_mode` off) would cut the remaining ispc search further. Not here: it changes encoded output and would need ground truth revalidated, which is a quality call to make separately.

## Validation

- full CI green on 85b390e ([run 30220582522](https://github.com/tqjxlm/Sparkle/actions/runs/30220582522)), all 34 checks
- `python3 dev/ci_matrix.py` byte-match; `tests.build_system.test_ci_matrix` 14/14; `clang-format` clean