### PR TITLE
[Android] move the toolchain to AGP 9.3 / Gradle 9.6

### DIFF
--- a/build_system/android/app/build.gradle
+++ b/build_system/android/app/build.gradle
@@ -1,17 +1,16 @@
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
 
 // arm64-v8a is the shipping ABI; x86_64 exists for emulators on x86 hosts (CI)
 def targetAbi = project.hasProperty('targetAbi') ? project.targetAbi : 'arm64-v8a'
 
 android {
-    compileSdk 35
-    ndkVersion '28.1.13356709'
+    compileSdk 37
+    ndkVersion '29.0.14206865'
     
     defaultConfig {
         applicationId 'io.tqjxlm.sparkle'
         minSdk 31
-        targetSdk 35
+        targetSdk 37
         externalNativeBuild {
             cmake {
                 def fixedArgs = [
@@ -34,7 +33,7 @@ android {
                 //noinspection ChromeOsAbiSupport
                 abiFilters targetAbi
             }
-            signingConfig signingConfigs.debug
+            signingConfig = signingConfigs.debug
         }
         debug {
             packaging {
@@ -142,31 +141,41 @@ tasks.register('copyAssets', Copy) {
     outputs.dir "${project.projectDir}/src/main/assets"
 }
 
-// make sure copyAssets runs before the mergeAssets task and after the externalNativeBuild task
-android.applicationVariants.configureEach { variant ->
-    def variantName = variant.name.capitalize()
-    def nativeBuild = tasks.named("externalNativeBuild${variantName}")
-    def generateManifests = tasks.named("generateAssetManifests")
-    def copyAssets = tasks.named("copyAssets")
+// onVariants names the variants, but the AGP tasks wired below are only registered once the
+// project is evaluated, so the lookups wait for afterEvaluate
+def variantNames = []
+androidComponents {
+    onVariants { variant ->
+        variantNames.add(variant.name.capitalize())
+    }
+}
 
-    generateManifests.configure {
-        mustRunAfter nativeBuild
-    }
-    copyAssets.configure {
-        mustRunAfter nativeBuild
-    }
-    if (variantName == "Release") {
-        // release lint reads the generated assets copied into the main source set
-        tasks.named("generateReleaseLintVitalReportModel").configure {
-            mustRunAfter copyAssets
+// make sure copyAssets runs before the mergeAssets task and after the externalNativeBuild task
+afterEvaluate {
+    variantNames.each { variantName ->
+        def nativeBuild = tasks.named("externalNativeBuild${variantName}")
+        def generateManifests = tasks.named("generateAssetManifests")
+        def copyAssets = tasks.named("copyAssets")
+
+        generateManifests.configure {
+            mustRunAfter nativeBuild
         }
-        tasks.named("lintVitalAnalyzeRelease").configure {
-            mustRunAfter copyAssets
+        copyAssets.configure {
+            mustRunAfter nativeBuild
         }
-    }
-    tasks.named("merge${variantName}Assets").configure {
-        dependsOn nativeBuild
-        dependsOn copyAssets
+        if (variantName == "Release") {
+            // release lint reads the generated assets copied into the main source set
+            tasks.named("generateReleaseLintVitalReportModel").configure {
+                mustRunAfter copyAssets
+            }
+            tasks.named("lintVitalAnalyzeRelease").configure {
+                mustRunAfter copyAssets
+            }
+        }
+        tasks.named("merge${variantName}Assets").configure {
+            dependsOn nativeBuild
+            dependsOn copyAssets
+        }
     }
 }
 

--- a/build_system/android/app/build.gradle
+++ b/build_system/android/app/build.gradle
@@ -28,7 +28,8 @@ android {
     buildTypes {
         release {
             minifyEnabled = true
-            proguardFiles getDefaultProguardFile('proguard-android.txt')
+            // the non-optimize variant carries -dontoptimize and AGP 9 rejects it
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt')
             ndk {
                 //noinspection ChromeOsAbiSupport
                 abiFilters targetAbi

--- a/build_system/android/app/build.gradle
+++ b/build_system/android/app/build.gradle
@@ -139,18 +139,11 @@ tasks.register('copyAssets', Copy) {
     outputs.dir "${project.projectDir}/src/main/assets"
 }
 
-// onVariants names the variants, but the AGP tasks wired below are only registered once the
-// project is evaluated, so the lookups wait for afterEvaluate
-def variantNames = []
-androidComponents {
-    onVariants { variant ->
-        variantNames.add(variant.name.capitalize())
-    }
-}
-
-// make sure copyAssets runs before the mergeAssets task and after the externalNativeBuild task
+// with no product flavors declared, a variant is named after its build type. the wiring waits
+// for afterEvaluate because AGP registers the tasks it names while the project is evaluated.
 afterEvaluate {
-    variantNames.each { variantName ->
+    android.buildTypes.each { buildType ->
+        def variantName = buildType.name.capitalize()
         def nativeBuild = tasks.named("externalNativeBuild${variantName}")
         def generateManifests = tasks.named("generateAssetManifests")
         def copyAssets = tasks.named("copyAssets")

--- a/build_system/android/app/build.gradle
+++ b/build_system/android/app/build.gradle
@@ -62,13 +62,10 @@ android {
         prefab true
     }
 
+    // built-in kotlin takes its jvmTarget from targetCompatibility
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
     }
 
     sourceSets {

--- a/build_system/android/build.gradle
+++ b/build_system/android/build.gradle
@@ -4,8 +4,9 @@ buildscript {
        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.10.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0"
+        // the kotlin gradle plugin arrives as an AGP runtime dependency: AGP 9 compiles the
+        // app's kotlin itself and rejects the standalone org.jetbrains.kotlin.android plugin
+        classpath 'com.android.tools.build:gradle:9.3.0'
     }
 }
 allprojects {

--- a/build_system/android/gradle.properties
+++ b/build_system/android/gradle.properties
@@ -1,4 +1,3 @@
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 org.gradle.parallel=true

--- a/build_system/android/gradle/wrapper/gradle-wrapper.properties
+++ b/build_system/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -273,6 +273,8 @@ open build_system/macos/project/sparkle.xcodeproj      # or build_system/ios/pro
 
 ### Android Studio (Only for android framework)
 
+The project builds with Android Gradle Plugin 9.3, which needs a matching Android Studio (Panda 3 or newer) and JDK 17 or newer to sync.
+
 ``` shell
 python3 build.py --framework=android --generate_only
 # open project folder `build_system/android` in Android Studio


### PR DESCRIPTION
Takes the Android toolchain to the current releases. AGP 9 is a breaking major, so this is a build-script migration rather than a pure version bump.

## Versions

| | before | after |
|---|---|---|
| Android Gradle Plugin | 8.10.1 | 9.3.0 |
| Gradle | 8.14.2 | 9.6.1 |
| Kotlin Gradle Plugin | 2.1.0, declared | supplied by AGP |
| compileSdk / targetSdk | 35 | 37 |
| NDK | 28.1.13356709 | 29.0.14206865 |

AGP 9.3 requires Gradle 9.5.0 or newer, and API 37 requires AGP 9.1.1 or newer, so the two move together.

## Migration the new AGP forces

**The old variant API is gone.** `android.applicationVariants` was removed in AGP 9.0, and AGP 9's `androidComponents` extension does not expose `onVariants` to a Groovy closure either. The wiring only ever needed variant *names* to build task names, and this app declares no product flavors, so the names now come from `android.buildTypes` and no AGP API is involved. The lookups sit in `afterEvaluate` because AGP registers `externalNativeBuild*`, `merge*Assets` and the lint tasks during evaluation. The ordering itself — `copyAssets` and `generateAssetManifests` after the native build, both before `merge*Assets`, and release lint after `copyAssets` — is unchanged.

**Kotlin is built into AGP now.** AGP 9 compiles the app's Kotlin itself and rejects `org.jetbrains.kotlin.android`, so the plugin and its `classpath` entry are both removed; AGP carries the Kotlin Gradle Plugin as a runtime dependency. `kotlinOptions` is gone from the DSL with it — built-in Kotlin defaults `jvmTarget` to `android.compileOptions.targetCompatibility`, which already asks for 17, so the block was redundant rather than relocated.

**`proguard-android.txt` is rejected** because it carries `-dontoptimize`; the release build takes `proguard-android-optimize.txt`, which is what AGP's own error message directs.

**Jetifier is dropped.** `android.enableJetifier` only rewrites legacy support-library artifacts, and this app depends on `androidx.core`, `androidx.appcompat` and `androidx.games` alone.

## What is not changed

- androidx library versions — Google's maven is not reachable from where this was prepared, so their current versions could not be confirmed; guessing at version strings would only break resolution. Happy to bump them separately.
- `EMULATOR_API_LEVEL` stays at 35. An app with `targetSdk 37` installs and runs on an API 35 emulator, and moving the system image is a separate risk to the test job.
- `-DANDROID_PLATFORM=35` stays. It sets the native minimum API, not the compile target.

## Result

CI is green on the full matrix, including all three Android builds and the emulator test. The Android build takes 17m21s and reports zero compiler diagnostics under NDK r29, so its stricter header and flag rules cost nothing here.

One expectation this does **not** meet: the Gradle deprecation notice does not disappear, it moves forward a major.

```
before:  Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
after:   Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.
```

That is good evidence the deprecated API calls come from AGP and Kotlin internals rather than from this repository's build scripts — upgrading moves the plugins onto the next set of soon-to-be-deprecated APIs and the notice re-targets. Silencing it would need `--warning-mode all` to attribute the calls, and they would still not be ours to fix.
